### PR TITLE
Added configuration for basic auth for ES_HTTP dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ Configuration should be done via the `metrics` Gradle extension.
         hostname = 'myescluster'    // default is 'localhost'
         httpPort = 59300            // default is 9200
         indexName = 'myindexname'   // default is 'build-metrics-default'       
-        dispatcherType = 'ES_HTTP'  // default is the Elasticsearch HTTP client. ES_CLIENT is also available. 
+        dispatcherType = 'ES_HTTP'  // default is the Elasticsearch HTTP client. ES_CLIENT is also available.
+        esBasicAuthUsername = 'user' // only for ES_HTTP.  If not set, no authentication will be used.
+        esBasicAuthPassword = 'pass' // this value should be read in from a properties file
     }
 
 ### REST configuration 

--- a/src/integTest/groovy/nebula/plugin/metrics/RestMetricsIntegTest.groovy
+++ b/src/integTest/groovy/nebula/plugin/metrics/RestMetricsIntegTest.groovy
@@ -43,19 +43,19 @@ class RestMetricsIntegTest extends IntegrationSpec {
                 throw new IllegalStateException('Metrics plugin should only POST data')
             }
             def response = 'OK'
-            t.sendResponseHeaders(200, response.length());
-            OutputStream os = t.getResponseBody();
-            os.write(response.getBytes());
-            os.close();
+            t.sendResponseHeaders(200, response.length())
+            OutputStream os = t.getResponseBody()
+            os.write(response.getBytes())
+            os.close()
         }
 
     }
 
     def 'metrics posts data to preconfigured REST server'() {
         HttpServer server = HttpServer.create(new InetSocketAddress(1337), 0)
-        server.createContext("/", new RestMockHandler());
-        server.setExecutor(null);
-        server.start();
+        server.createContext("/", new RestMockHandler())
+        server.setExecutor(null)
+        server.start()
 
         buildFile << """
             ${applyPlugin(MetricsPlugin)}
@@ -70,7 +70,7 @@ class RestMetricsIntegTest extends IntegrationSpec {
         runTasksSuccessfully('projects')
 
         then:
-        RestPayload restPayload = getObjectMapper().readValue(lastReportedBuildMetricsEvent, RestPayload.class);
+        RestPayload restPayload = getObjectMapper().readValue(lastReportedBuildMetricsEvent, RestPayload.class)
         def buildJson = new JsonSlurper().parseText(restPayload.payload.get('build'))
 
         restPayload.eventName == 'build_metrics'
@@ -85,6 +85,9 @@ class RestMetricsIntegTest extends IntegrationSpec {
             tasks.size() == 1
             tests.isEmpty()
         }
+
+        cleanup:
+        server?.stop(0)
     }
 
 }

--- a/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
@@ -50,6 +50,8 @@ public class MetricsPluginExtension {
     private String clusterName = "elasticsearch";
     private String indexName = DEFAULT_INDEX_NAME;
     private LogLevel logLevel = DEFAULT_LOG_LEVEL;
+    private String esBasicAuthUsername;
+    private String esBasicAuthPassword;
 
     private String restUri = "http://localhost/metrics";
     private String restBuildEventName = "build_metrics";
@@ -66,6 +68,22 @@ public class MetricsPluginExtension {
 
     public void setHostname(String hostname) {
         this.hostname = checkNotNull(hostname);
+    }
+
+    public String getEsBasicAuthUsername() {
+        return esBasicAuthUsername;
+    }
+
+    public void setEsBasicAuthUsername(String esBasicAuthUsername) {
+        this.esBasicAuthUsername = checkNotNull(esBasicAuthUsername);
+    }
+
+    public String getEsBasicAuthPassword() {
+        return esBasicAuthPassword;
+    }
+
+    public void setEsBasicAuthPassword(String esBasicAuthPassword) {
+        this.esBasicAuthPassword = checkNotNull(esBasicAuthPassword);
     }
 
     public int getTransportPort() {

--- a/src/main/java/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcher.java
@@ -18,6 +18,7 @@
 package nebula.plugin.metrics.dispatcher;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import io.searchbox.action.Action;
 import io.searchbox.client.JestClient;
@@ -49,10 +50,13 @@ public final class HttpESMetricsDispatcher extends AbstractESMetricsDispatcher {
     @Override
     protected void startUpClient() {
         JestClientFactory factory = new JestClientFactory();
-        factory.setHttpClientConfig(new HttpClientConfig
+        HttpClientConfig.Builder config = new HttpClientConfig
                 .Builder("http://" + extension.getHostname() + ":" + extension.getHttpPort())
-                .multiThreaded(false)
-                .build());
+                .multiThreaded(false);
+        if(!Strings.isNullOrEmpty(extension.getEsBasicAuthUsername())) {
+            config.defaultCredentials(extension.getEsBasicAuthUsername(), extension.getEsBasicAuthPassword());
+        }
+        factory.setHttpClientConfig(config.build());
         client = factory.getObject();
     }
 

--- a/src/test/groovy/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcherTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcherTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2015-2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package nebula.plugin.metrics.dispatcher
+
+import com.sun.net.httpserver.BasicAuthenticator
+import com.sun.net.httpserver.HttpContext
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import nebula.plugin.metrics.MetricsPluginExtension
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class HttpESMetricsDispatcherTest extends Specification {
+
+    private final static String user = 'user'
+    private final static String pass = 'pass'
+    private final static String context = '/'
+    private final static int esPort = 1337
+
+    @Unroll
+    def "HttpESMetricsDispatcher should use basic auth if configured: #basicAuth"(boolean basicAuth) {
+        given: 'running mock ES instance and HttpESMetricsDispatcher, both using basic auth if configured'
+        HttpServer mockEsInstance = createMockEsInstance(basicAuth)
+        mockEsInstance.start()
+        MetricsPluginExtension metrics = new MetricsPluginExtension()
+        metrics.setHostname('localhost')
+        metrics.setHttpPort(esPort)
+        metrics.setIndexName('index')
+        if (basicAuth) {
+            metrics.setEsBasicAuthUsername(user)
+            metrics.setEsBasicAuthPassword(pass)
+        }
+        HttpESMetricsDispatcher dispatcher = new HttpESMetricsDispatcher(metrics)
+        dispatcher.startAsync().awaitRunning()
+
+        when: 'dispatcher tries to create an index'
+        def indexExists = dispatcher.exists('index')
+
+        then: 'request should succeed, and we should see a valid response'
+        noExceptionThrown()
+        indexExists
+
+        cleanup:
+        mockEsInstance?.stop(0)
+
+        where: basicAuth << [true, false]
+    }
+
+    private static HttpServer createMockEsInstance(boolean basicAuth) {
+        HttpServer mockEsInstance = HttpServer.create(new InetSocketAddress(esPort), 0)
+        HttpContext rootCtx = mockEsInstance.createContext(context, buildEsHttpHandler())
+        if (basicAuth) {
+            rootCtx.setAuthenticator(new BasicAuthenticator(context) {
+                @Override
+                boolean checkCredentials(String username, String password) {
+                    username == user && password == pass
+                }
+            })
+        }
+        mockEsInstance
+    }
+
+    private static HttpHandler buildEsHttpHandler() {
+        new HttpHandler() {
+            @Override
+            void handle(HttpExchange t) throws IOException {
+                def response = "{\"found\": true}"
+                t.sendResponseHeaders(200, response.length())
+                OutputStream os = t.getResponseBody()
+                os.write(response.getBytes())
+                os.close()
+            }
+        }
+    }
+}


### PR DESCRIPTION
- allows `ES_HTTP` dispatcher to work with instances of Elasticsearch protected by basic auth, with the following config options:

```
metrics {
  ...
  dispatcherType = 'ES_HTTP'
  esBasicAuthUsername = 'user'
  esBasicAuthPassword = 'pass'
  ...
}
```
- these values ideally will be set in a `gradle.properties` file instead of being hardcoded into the build
