### PR TITLE
Splunk Dispatcher 

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ TBD
  
 # Data Population
 
-`gradle-build-metrics` can be currently configured to persist data against either Elasticsearch, a generic REST endpoint or to Splunk Indexer/Forwarder. If configured 
+`gradle-build-metrics` can be currently configured to persist data against either Elasticsearch, a generic REST endpoint or to a Splunk Indexer/Forwarder. If configured 
 to use Elasticsearch, data is persisted to the `build-metrics-default` and `logstash-build-metrics-default-yyyyMM` indices for 
 `build` and `log` events respectively. For the REST configuration, both types of data are POSTed to the same endpoint, but the payload 
 varies based on type:
@@ -185,7 +185,12 @@ logs:
 ]
 ```
 
-If configured to use Splunk, there will be two input types to index the build event, 1) using a *Splunk Forwarder* or 2) using the *Splunk indexer HTTP Event Collector*. If **FORWARDER** is chosen, the data build event will be persisted in the forwarder configured *index* and *sourcetype*. If **HTTP_COLLECTOR** is chosen the data will be indexed according to the event collector configuration in the Splunk Indexer.
+If configured to use Splunk, there will be two input types to index the build event:
+
+* *Splunk Forwarder*
+* *Splunk indexer HTTP Event Collector*
+
+If **FORWARDER** is chosen, the data build event will be persisted in the forwarder configured *index* and *sourcetype*. If **HTTP_COLLECTOR** is chosen the data will be indexed according to the event collector configuration in the Splunk Indexer.
 
 # Custom Metrics 
 
@@ -257,7 +262,7 @@ Configuration should be done via the `metrics` Gradle extension.
 
         splunkInputType = 'FORWARDER'                                                                    // input type to persist the build event
         splunkUri = 'https://mysplunk.com/services/receivers/simple?index=main&sourcetype=gradle_builds' // splunk forwarder URI, here the sourcetype and the index could be defined
-        headers['Authorization'] = 'Basic YWRtaW46Y2hhbmdlbWU='                                          // basic auth with user and password is mandatory to request via Splunk Forwarder 
+        headers['Authorization'] = 'Basic YWRtaW46Y2hhbmdlbWU='                                          // basic auth with user and password base64 is mandatory to request via Splunk Forwarder 
     }
 
 # Metrics

--- a/README.md
+++ b/README.md
@@ -231,7 +231,9 @@ Configuration should be done via the `metrics` Gradle extension.
         dispatcherType = 'REST'
         restUri = 'https://server.com/rest/endpoint'      // default is 'http://localhost/metrics'
         restBuildEventName = 'my_build_events'            // default is 'build_metrics'
-        restLogEventName = 'my_log_events'                // default is 'build_logs'                      
+        restLogEventName = 'my_log_events'                // default is 'build_logs'  
+
+        headers['myHeader_key'] = 'header_value'          // optional, default is empty MAP object
     } 
 
 ### Splunk configuration 
@@ -255,7 +257,7 @@ Configuration should be done via the `metrics` Gradle extension.
 
         splunkInputType = 'FORWARDER'                                                                    // input type to persist the build event
         splunkUri = 'https://mysplunk.com/services/receivers/simple?index=main&sourcetype=gradle_builds' // splunk forwarder URI, here the sourcetype and the index could be defined
-        headers['Authorization'] = 'Basic YWRtaW46Y2hhbmdlbWU='                                          // basic auth with user and password is mandatory to request via Splunk Forwarder  
+        headers['Authorization'] = 'Basic YWRtaW46Y2hhbmdlbWU='                                          // basic auth with user and password is mandatory to request via Splunk Forwarder 
     }
 
 # Metrics

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ TBD
  
 # Data Population
 
-`gradle-build-metrics` can be currently configured to persist data against either Elasticsearch or a generic REST endpoint. If configured 
+`gradle-build-metrics` can be currently configured to persist data against either Elasticsearch, a generic REST endpoint or to Splunk Indexer/Forwarder. If configured 
 to use Elasticsearch, data is persisted to the `build-metrics-default` and `logstash-build-metrics-default-yyyyMM` indices for 
 `build` and `log` events respectively. For the REST configuration, both types of data are POSTed to the same endpoint, but the payload 
 varies based on type:
@@ -184,6 +184,8 @@ logs:
   }
 ]
 ```
+
+If configured to use Splunk, there will be two input types to index the build event, 1) using a *Splunk Forwarder* or 2) using the *Splunk indexer HTTP Event Collector*. If **FORWARDER** is chosen, the data build event will be persisted in the forwarder configured *index* and *sourcetype*. If **HTTP_COLLECTOR** is chosen the data will be indexed according to the event collector configuration in the Splunk Indexer.
 
 # Custom Metrics 
 
@@ -231,6 +233,30 @@ Configuration should be done via the `metrics` Gradle extension.
         restBuildEventName = 'my_build_events'            // default is 'build_metrics'
         restLogEventName = 'my_log_events'                // default is 'build_logs'                      
     } 
+
+### Splunk configuration 
+
+**IMPORTANT**: to use `gradle-metrics-plugin` with Splunk, it is required to add the self-signed Splunk ssl certificate to the JDK keyStore.
+
+#### Splunk HTTP_COLLETOR
+
+    metrics {
+        dispatcherType = 'SPLUNK'
+
+        splunkInputType = 'HTTP_COLLECTOR'                                        // input type to persist the build event
+        splunkUri = 'https://mysplunk.com/services/collector'                     // splunk indexer URI for Http Collector
+        headers['Authorization'] = 'Splunk 8BA5A780-6B3A-472D-BF2F-CF4E9FFF4E9D'  // Splunk Auth token is mandatory Authorization header for HTTP Collector  
+    }
+
+#### Splunk FORWARDER
+
+    metrics {
+        dispatcherType = 'SPLUNK'
+
+        splunkInputType = 'FORWARDER'                                                                    // input type to persist the build event
+        splunkUri = 'https://mysplunk.com/services/receivers/simple?index=main&sourcetype=gradle_builds' // splunk forwarder URI, here the sourcetype and the index could be defined
+        headers['Authorization'] = 'Basic YWRtaW46Y2hhbmdlbWU='                                          // basic auth with user and password is mandatory to request via Splunk Forwarder  
+    }
 
 # Metrics
 

--- a/src/integTest/groovy/nebula/plugin/metrics/SplunkMetricsIntegTest.groovy
+++ b/src/integTest/groovy/nebula/plugin/metrics/SplunkMetricsIntegTest.groovy
@@ -73,8 +73,7 @@ class SplunkMetricsIntegTest extends IntegrationSpec {
 
                 splunkInputType = 'FORWARDER'
                 splunkUri = 'http://localhost:1337/'
-                splunkHeaderMap = [:]
-                splunkHeaderMap['Authorization'] = 'Basic YWRtaW46Y2hhbmdlbWU='
+                headers['Authorization'] = 'Basic YWRtaW46Y2hhbmdlbWU='
             }
         """.stripIndent()
 
@@ -113,8 +112,7 @@ class SplunkMetricsIntegTest extends IntegrationSpec {
 
                 splunkInputType = 'HTTP_COLLECTOR'
                 splunkUri = 'http://localhost:1338/'
-                splunkHeaderMap = [:]
-                splunkHeaderMap['Authorization'] = 'Splunk 8BA5A780-6B3A-472D-BF2F-CF4E9FFF4E9D'
+                headers['Authorization'] = 'Splunk 8BA5A780-6B3A-472D-BF2F-CF4E9FFF4E9D'
             }
         """.stripIndent()
 

--- a/src/integTest/groovy/nebula/plugin/metrics/SplunkMetricsIntegTest.groovy
+++ b/src/integTest/groovy/nebula/plugin/metrics/SplunkMetricsIntegTest.groovy
@@ -1,0 +1,104 @@
+/*
+ *  Copyright 2015-2016 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package nebula.plugin.metrics
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler
+import com.sun.net.httpserver.HttpServer
+import groovy.json.JsonSlurper
+import nebula.test.IntegrationSpec
+import org.apache.commons.io.IOUtils
+import org.apache.http.StatusLine
+
+import org.apache.http.client.fluent.Request
+import org.apache.http.entity.ContentType
+
+import org.apache.log4j.Logger
+
+class SplunkMetricsIntegTest extends IntegrationSpec {
+
+    final static Logger logger = Logger.getLogger(SplunkMetricsIntegTest.class);
+
+    String lastReportedBuildMetricsEvent
+    private def slurper = new JsonSlurper()
+
+    class SplunkEndPointMock implements HttpHandler {
+
+        public void handle(HttpExchange t) throws IOException {
+            
+            def response = 'OK'
+            if (t.getRequestMethod() == 'POST') {
+
+                def splunkHeader = 'Basic YWRtaW46Y2hhbmdlbWU='
+                def authHeader = t.getRequestHeaders()['Authorization'][0]
+
+                if (authHeader == splunkHeader){ 
+                    lastReportedBuildMetricsEvent = IOUtils.toString(t.getRequestBody())
+                    
+                    t.sendResponseHeaders(200, response.length())
+                } else {
+                    response = 'Unauthorized'
+                    t.sendResponseHeaders(401, response.length())
+                }
+                OutputStream os = t.getResponseBody()
+                os.write(response.getBytes())
+                os.close()
+            }
+        }
+    }
+
+    def 'metrics posts data to Mocked Splunk Universal forwarder with Basic Authorization Header'() {
+        HttpServer server = HttpServer.create(new InetSocketAddress(1337), 0)
+        server.createContext("/", new SplunkEndPointMock())
+        server.setExecutor(null)
+        server.start()
+
+        buildFile << """
+            ${applyPlugin(MetricsPlugin)}
+
+            metrics {
+                dispatcherType = 'SPLUNK'
+
+                splunkInputType = 'FORWARDER'
+                splunkUri = 'http://localhost:1337/'
+                splunkAuthHeader = 'Basic YWRtaW46Y2hhbmdlbWU='
+            }
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully('projects')
+
+        then:
+        def buildJson = slurper.parseText(lastReportedBuildMetricsEvent)
+
+        buildJson.with {
+            buildInfo.project.name == moduleName
+            buildInfo.project.version == 'unspecified'
+            buildInfo.startTime
+            buildInfo.finishedTime
+            buildInfo.elapsedTime
+            buildInfo.result.status == 'success'
+            !buildInfo.events.isEmpty()
+            buildInfo.tasks.size() == 1
+            buildInfo.tests.isEmpty()
+        }
+
+        cleanup:
+        server?.stop(0)
+    }
+}

--- a/src/main/java/nebula/plugin/metrics/MetricsPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPlugin.java
@@ -92,6 +92,10 @@ public final class MetricsPlugin implements Plugin<Project> {
                             dispatcher = new HttpESMetricsDispatcher(extension);
                             break;
                         }
+                        case SPLUNK: {
+                            dispatcher = new SplunkMetricsDispatcher(extension);
+                            break;
+                        }
                         case REST: {
                             dispatcher = new RestMetricsDispatcher(extension);
                             break;

--- a/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
@@ -62,7 +62,7 @@ public class MetricsPluginExtension {
 
     private String splunkUri = "http://localhost/";
     private String splunkInputType = "HTTP_COLLECTOR";
-    private HashMap<String,String> splunkHeaderMap = new HashMap<String,String>();
+    private HashMap<String,String> headers = new HashMap<String,String>();
 
     private DispatcherType dispatcherType = DispatcherType.ES_HTTP;
     private List<String> sanitizedProperties = new ArrayList<>();
@@ -179,12 +179,12 @@ public class MetricsPluginExtension {
         this.splunkInputType = checkNotNull(splunkInputType);
     }
 
-    public void setSplunkHeaderMap(HashMap<String,String> splunkHeaderMap) {
-        this.splunkHeaderMap = checkNotNull(splunkHeaderMap);
+    public void setHeaders(HashMap<String,String> headers) {
+        this.headers = checkNotNull(headers);
     }
 
-    public HashMap<String,String> getSplunkHeaderMap() {
-        return splunkHeaderMap;
+    public HashMap<String,String> getHeaders() {
+        return headers;
     }
 
     public String getRestBuildEventName() {

--- a/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
@@ -59,6 +59,10 @@ public class MetricsPluginExtension {
     private String restBuildEventName = "build_metrics";
     private String restLogEventName = "build_logs";
 
+    private String splunkUri = "http://localhost/";
+    private String splunkAuthHeader = "httpCollectorToken";
+    private String splunkInputType = "HTTP_COLLECTOR";
+
     private DispatcherType dispatcherType = DispatcherType.ES_HTTP;
     private List<String> sanitizedProperties = new ArrayList<>();
     private boolean failOnError = true;
@@ -158,6 +162,30 @@ public class MetricsPluginExtension {
         this.restLogEventName = checkNotNull(restLogEventName);
     }
 
+    public String getSplunkUri() {
+        return splunkUri;
+    }
+
+    public void setSplunkUri(String splunkUri) {
+        this.splunkUri = checkNotNull(splunkUri);
+    }
+
+    public String getSplunkAuthHeader() {
+        return splunkAuthHeader;
+    }
+
+    public void setSplunkAuthHeader(String splunkAuthHeader) {
+        this.splunkAuthHeader = checkNotNull(splunkAuthHeader);
+    }
+
+    public String getSplunkInputType() {
+        return splunkInputType;
+    }
+
+    public void setSplunkInputType(String splunkInputType) {
+        this.splunkInputType = checkNotNull(splunkInputType);
+    }
+
     public String getRestBuildEventName() {
         return restBuildEventName;
     }
@@ -209,6 +237,7 @@ public class MetricsPluginExtension {
     public enum DispatcherType {
         ES_CLIENT,
         ES_HTTP,
+        SPLUNK,
         REST,
         NOOP
     }

--- a/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
@@ -24,6 +24,7 @@ import org.joda.time.format.DateTimeFormatter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashMap;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -60,8 +61,8 @@ public class MetricsPluginExtension {
     private String restLogEventName = "build_logs";
 
     private String splunkUri = "http://localhost/";
-    private String splunkAuthHeader = "httpCollectorToken";
     private String splunkInputType = "HTTP_COLLECTOR";
+    private HashMap<String,String> splunkHeaderMap = new HashMap<String,String>();
 
     private DispatcherType dispatcherType = DispatcherType.ES_HTTP;
     private List<String> sanitizedProperties = new ArrayList<>();
@@ -170,20 +171,20 @@ public class MetricsPluginExtension {
         this.splunkUri = checkNotNull(splunkUri);
     }
 
-    public String getSplunkAuthHeader() {
-        return splunkAuthHeader;
-    }
-
-    public void setSplunkAuthHeader(String splunkAuthHeader) {
-        this.splunkAuthHeader = checkNotNull(splunkAuthHeader);
-    }
-
     public String getSplunkInputType() {
         return splunkInputType;
     }
 
     public void setSplunkInputType(String splunkInputType) {
         this.splunkInputType = checkNotNull(splunkInputType);
+    }
+
+    public void setSplunkHeaderMap(HashMap<String,String> splunkHeaderMap) {
+        this.splunkHeaderMap = checkNotNull(splunkHeaderMap);
+    }
+
+    public HashMap<String,String> getSplunkHeaderMap() {
+        return splunkHeaderMap;
     }
 
     public String getRestBuildEventName() {

--- a/src/main/java/nebula/plugin/metrics/dispatcher/RestMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/RestMetricsDispatcher.java
@@ -81,7 +81,7 @@ public class RestMetricsDispatcher extends AbstractMetricsDispatcher {
         postPayload(joinMultiplePayloads(payloads));
     }
 
-    public void postPayload(String payload) {
+    protected void postPayload(String payload) {
         checkNotNull(payload);
 
         try {
@@ -120,7 +120,7 @@ public class RestMetricsDispatcher extends AbstractMetricsDispatcher {
         }
     }
 
-    public Request addHeaders(Request req) {
+    protected Request addHeaders(Request req) {
         checkNotNull(req);
 
         for (Map.Entry<String, String> entry : extension.getHeaders().entrySet()) {

--- a/src/main/java/nebula/plugin/metrics/dispatcher/RestMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/RestMetricsDispatcher.java
@@ -87,7 +87,7 @@ public class RestMetricsDispatcher extends AbstractMetricsDispatcher {
         try {
             Request postReq = Request.Post(extension.getRestUri());
             postReq.bodyString(payload , ContentType.APPLICATION_JSON);
-            postReq = addHeaders(postReq);
+            addHeaders(postReq);
             postReq.execute();
         } catch (IOException e) {
             throw new RuntimeException("Unable to POST to " + extension.getRestUri(), e);
@@ -120,13 +120,12 @@ public class RestMetricsDispatcher extends AbstractMetricsDispatcher {
         }
     }
 
-    protected Request addHeaders(Request req) {
+    protected void addHeaders(Request req) {
         checkNotNull(req);
 
         for (Map.Entry<String, String> entry : extension.getHeaders().entrySet()) {
             req.addHeader(entry.getKey(),entry.getValue());
         }
-        return req;
     }
 
     @VisibleForTesting

--- a/src/main/java/nebula/plugin/metrics/dispatcher/SplunkMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/SplunkMetricsDispatcher.java
@@ -56,7 +56,7 @@ public class SplunkMetricsDispatcher extends RestMetricsDispatcher {
     	
         /*
         *  The only event we want to submit to splunk is the complete build info,
-        *  this switch will exclude the logstach from posting
+        *  this switch will exclude the logstash from posting
         */
         if(build.getEvents().isEmpty()){
             this.submit = false;

--- a/src/main/java/nebula/plugin/metrics/dispatcher/SplunkMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/SplunkMetricsDispatcher.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright 2015-2016 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package nebula.plugin.metrics.dispatcher;
+
+import nebula.plugin.metrics.model.*;
+import nebula.plugin.metrics.MetricsPluginExtension;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+
+import java.util.Collection;
+import java.util.UUID;
+import java.io.IOException;
+
+import org.apache.http.entity.ContentType;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.StatusLine;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+public class SplunkMetricsDispatcher extends RestMetricsDispatcher {
+
+    protected static final String HTTP_COLLECTOR = "HTTP_COLLECTOR";
+    protected static final String FORWARDER = "FORWARDER";
+    
+    private Boolean submit = false;
+    private String error = null;
+
+    public SplunkMetricsDispatcher(MetricsPluginExtension extension) {
+        super(extension);
+        buildId = Optional.of(UUID.randomUUID().toString());
+    }
+
+	@Override
+	protected Object transformBuild(Build build) {
+        checkNotNull(build);
+    	
+        /*
+        *  The only event we want to submit to splunk is the complete build info 
+        */
+        if(build.getEvents().isEmpty()){
+            this.submit = false;
+        } else {
+            this.submit = true;
+        }
+
+        return build;
+    }
+
+    @Override
+    protected String index(String indexName, String type, String source, Optional<String> id){
+        checkNotNull(indexName);
+        checkNotNull(type);
+        checkNotNull(source);
+        checkNotNull(id);
+
+        String requestBody = getSplunkRequestBody(source, buildId.get());
+
+        if (BUILD_TYPE.equals(type) && submit && requestBody != null) {
+            postToSplunk(requestBody);
+        }
+
+    	return buildId.get();
+    }
+
+    private void postToSplunk(String requestBody) {
+        try {
+
+            Request postReq = Request.Post(extension.getSplunkUri());
+            postReq.bodyString(requestBody , ContentType.APPLICATION_JSON);
+            postReq.addHeader("Authorization",extension.getSplunkAuthHeader());
+            StatusLine status = postReq.execute().returnResponse().getStatusLine();
+
+            if (status.getStatusCode() != 200) {
+                error = String.format("%s (status code: %s)", 
+                    status.getReasonPhrase(), status.getStatusCode());
+            }
+        } catch (IOException e) {
+            error = e.getMessage();
+        }
+
+    }
+
+    private String getSplunkRequestBody(String buildInfo, String buildId) {
+        
+        String body = null;
+
+        switch(extension.getSplunkInputType()){
+            case HTTP_COLLECTOR: 
+                body = String.format("{\"event\": {\"buildId\": \"%s\", \"buildInfo\": %s}}",
+                    buildId, buildInfo);
+                break;
+            case FORWARDER:
+                body = String.format("{\"buildId\": \"%s\", \"buildInfo\": %s}",
+                    buildId, buildInfo);
+                break;
+        }
+        return body;
+    }
+
+    @Override
+    public Optional<String> receipt() {
+        if (error == null) {
+            return Optional.of(String.format("Metrics have been posted to %s (buildId: %s)", 
+                extension.getSplunkUri(), buildId.get()));
+        } else {
+            return Optional.of(String.format("Could not post metrics : %s ",error));
+        }
+    }
+}

--- a/src/main/java/nebula/plugin/metrics/dispatcher/SplunkMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/SplunkMetricsDispatcher.java
@@ -84,7 +84,7 @@ public class SplunkMetricsDispatcher extends RestMetricsDispatcher {
     }
 
     @Override
-    public void postPayload(String requestBody) {
+    protected void postPayload(String requestBody) {
         try {
 
             Request postReq = Request.Post(extension.getSplunkUri());

--- a/src/main/java/nebula/plugin/metrics/dispatcher/SplunkMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/SplunkMetricsDispatcher.java
@@ -89,7 +89,7 @@ public class SplunkMetricsDispatcher extends RestMetricsDispatcher {
 
             Request postReq = Request.Post(extension.getSplunkUri());
             postReq.bodyString(requestBody , ContentType.APPLICATION_JSON);
-            postReq = addHeaders(postReq);
+            addHeaders(postReq);
             StatusLine status = postReq.execute().returnResponse().getStatusLine();
 
             if (SC_OK != status.getStatusCode()) {

--- a/src/main/java/nebula/plugin/metrics/dispatcher/SplunkMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/SplunkMetricsDispatcher.java
@@ -126,12 +126,9 @@ public class SplunkMetricsDispatcher extends RestMetricsDispatcher {
         return body;
     }
 
-    private Request addHeaders(Request req){
-
-        Iterator it = extension.getSplunkHeaderMap().entrySet().iterator();
-        while (it.hasNext()) {
-            Map.Entry pair = (Map.Entry)it.next();
-            req.addHeader(pair.getKey().toString(),pair.getValue().toString());
+    private Request addHeaders(Request req) {
+        for (Map.Entry<String, String> entry : extension.getHeaders().entrySet()) {
+            req.addHeader(entry.getKey().toString(),entry.getValue().toString());
         }
         return req;
     }


### PR DESCRIPTION
The idea of this feature is to provide an out of the box solution to send the metrics via Post request to a Splunk service. The strategy to implement this feature was extending the RestMetricsDispatcher in order to:
- accept request headers
- evaluate the http response to provide an accurate output
- format the payload in order to fit Splunk requirements
