### PR TITLE
Add support for java detailed version information which contains value based on version/vendor/runtimeName

### DIFF
--- a/src/main/java/nebula/plugin/metrics/model/Info.java
+++ b/src/main/java/nebula/plugin/metrics/model/Info.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * Environment.
  */
 @Value
-@JsonPropertyOrder({"build", "scm", "ci", "environmentVariables", "systemProperties"})
+@JsonPropertyOrder({"build", "scm", "ci", "environmentVariables", "systemProperties", "javaVersion", "detailedJavaVersion"})
 public class Info {
     private static final String UNKNOWN = "UNKNOWN";
     private static final String OPEN_JDK = "OpenJDK";

--- a/src/main/java/nebula/plugin/metrics/model/Info.java
+++ b/src/main/java/nebula/plugin/metrics/model/Info.java
@@ -32,6 +32,14 @@ import java.util.Map;
 @Value
 @JsonPropertyOrder({"build", "scm", "ci", "environmentVariables", "systemProperties"})
 public class Info {
+    private static final String UNKNOWN = "UNKNOWN";
+    private static final String OPEN_JDK = "OpenJDK";
+    private static final String ORACLE_JDK = "Oracle";
+    private static final String SE_RUNTIME_ENVIRONMENT = "Java(TM) SE Runtime Environment";
+    private static final String HOTSPOT = "HotSpot(TM)";
+    private static final String EMPTY_STRING = "";
+    private static final String SPACE = " ";
+
     public static Info create(GradleToolContainer tool) {
         return create(tool, new UnknownTool(), new UnknownTool());
     }
@@ -80,11 +88,42 @@ public class Info {
     private List<KeyValue> systemProperties;
 
     public String getJavaVersion() {
+        String javaVersion = findProperty("java.version");
+        return !javaVersion.isEmpty() ? javaVersion : "unknown";
+    }
+
+    public String getDetailedJavaVersion() {
+        String javaRuntimeName = findProperty("java.runtime.name");
+        String javaVersion = findProperty("java.version");
+        String javaVendor = findProperty("java.vm.vendor");
+        return determineJavaVersion(javaRuntimeName, javaVersion, javaVendor);
+    }
+
+    private String findProperty(String propertyName) {
         for (KeyValue systemProperty : systemProperties) {
-            if (systemProperty.getKey().equals("java.version")) {
+            if (systemProperty.getKey().equals(propertyName)) {
                 return systemProperty.getValue();
             }
         }
-        return "unknown";
+        return EMPTY_STRING;
+    }
+
+    private String determineJavaVersion(String javaRuntimeName, String javaVersion, String javaVendor) {
+        if(javaVersion.isEmpty()) {
+          return UNKNOWN.toLowerCase();
+        }
+
+        String javaRuntimeNameLowerCase = javaRuntimeName.toLowerCase();
+        if(javaRuntimeName.toLowerCase().contains(OPEN_JDK.toLowerCase())) {
+            String version = OPEN_JDK.concat(SPACE).concat(javaVersion);
+            if(javaVendor.toLowerCase().contains("azul")) {
+                version = version.concat("-zulu");
+            }
+            return version;
+        } else if(javaRuntimeNameLowerCase.contains(SE_RUNTIME_ENVIRONMENT.toLowerCase()) || javaRuntimeNameLowerCase.contains(HOTSPOT.toLowerCase()) || javaRuntimeNameLowerCase.contains(ORACLE_JDK.toLowerCase())) {
+            return ORACLE_JDK.concat(SPACE).concat(javaVersion);
+        } else {
+            return UNKNOWN.concat(SPACE).concat(javaVersion);
+        }
     }
 }

--- a/src/test/groovy/nebula/plugin/metrics/model/InfoTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/model/InfoTest.groovy
@@ -19,6 +19,7 @@ package nebula.plugin.metrics.model
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import spock.lang.Specification
+import spock.lang.Unroll
 
 /**
  * Tests for {@link Info}.
@@ -33,7 +34,7 @@ class InfoTest extends Specification {
         def mapper = new ObjectMapper()
 
         expect:
-        mapper.writeValueAsString(info) == '{"build":{"type":null},"scm":{"type":null},"ci":{"type":null},"environmentVariables":[{"key":"mykey1","value":"myvalue1"},{"key":"mykey2","value":"myvalue2"}],"systemProperties":[],"javaVersion":"unknown"}'
+        mapper.writeValueAsString(info) == '{"build":{"type":null},"scm":{"type":null},"ci":{"type":null},"environmentVariables":[{"key":"mykey1","value":"myvalue1"},{"key":"mykey2","value":"myvalue2"}],"systemProperties":[],"javaVersion":"unknown","detailedJavaVersion":"unknown"}'
     }
 
     def 'properties are sanisited'() {
@@ -45,6 +46,32 @@ class InfoTest extends Specification {
 
         expect:
         def sanitizedInfo = Info.sanitize(info, Arrays.asList("mykey1"))
-        sanitizedInfo.systemProperties.find{ it.key == "mykey1" }.value == "SANITIZED"
+        sanitizedInfo.systemProperties.find { it.key == "mykey1" }.value == "SANITIZED"
+    }
+
+    @Unroll
+    def 'enhances Java version with details from runtime name and vendor - #description'() {
+        def env = new LinkedHashMap<String, String>()
+        env.put("mykey1", "myvalue1")
+        env.put("mykey2", "myvalue2")
+        def systemProperties = new LinkedHashMap<String, String>()
+        systemProperties.put("java.runtime.name", runtimeName)
+        systemProperties.put("java.version", version)
+        systemProperties.put("java.vm.vendor", vendor)
+        def tool = Mock(Tool)
+        def info = Info.create(tool, tool, tool, env, systemProperties)
+        def mapper = new ObjectMapper()
+
+        expect:
+        mapper.writeValueAsString(info) == expectedResult
+
+        where:
+        description                       | version     | runtimeName                         | vendor         | expectedResult
+        "is Oracle"                       | "1.8.0_181" | "Oracle"                            | ""             | '{"build":{"type":null},"scm":{"type":null},"ci":{"type":null},"environmentVariables":[{"key":"mykey1","value":"myvalue1"},{"key":"mykey2","value":"myvalue2"}],"systemProperties":[{"key":"java.runtime.name","value":"Oracle"},{"key":"java.version","value":"1.8.0_181"},{"key":"java.vm.vendor","value":""}],"javaVersion":"1.8.0_181","detailedJavaVersion":"Oracle 1.8.0_181"}'
+        "is Oracle"                       | "1.8.0_181" | "Java(TM) SE Runtime Environment"   | ""             | '{"build":{"type":null},"scm":{"type":null},"ci":{"type":null},"environmentVariables":[{"key":"mykey1","value":"myvalue1"},{"key":"mykey2","value":"myvalue2"}],"systemProperties":[{"key":"java.runtime.name","value":"Java(TM) SE Runtime Environment"},{"key":"java.version","value":"1.8.0_181"},{"key":"java.vm.vendor","value":""}],"javaVersion":"1.8.0_181","detailedJavaVersion":"Oracle 1.8.0_181"}'
+        "is Oracle"                       | "1.8.0_181" | "Java HotSpot(TM) 64-Bit Server VM" | ""             | '{"build":{"type":null},"scm":{"type":null},"ci":{"type":null},"environmentVariables":[{"key":"mykey1","value":"myvalue1"},{"key":"mykey2","value":"myvalue2"}],"systemProperties":[{"key":"java.runtime.name","value":"Java HotSpot(TM) 64-Bit Server VM"},{"key":"java.version","value":"1.8.0_181"},{"key":"java.vm.vendor","value":""}],"javaVersion":"1.8.0_181","detailedJavaVersion":"Oracle 1.8.0_181"}'
+        "is OpenJDK - zulu"               | "1.8.0_181" | "OpenJDK"                           | "Azul Systems" | '{"build":{"type":null},"scm":{"type":null},"ci":{"type":null},"environmentVariables":[{"key":"mykey1","value":"myvalue1"},{"key":"mykey2","value":"myvalue2"}],"systemProperties":[{"key":"java.runtime.name","value":"OpenJDK"},{"key":"java.version","value":"1.8.0_181"},{"key":"java.vm.vendor","value":"Azul Systems"}],"javaVersion":"1.8.0_181","detailedJavaVersion":"OpenJDK 1.8.0_181-zulu"}'
+        "is OpenJDK"                      | "1.8.0_181" | "OpenJDK"                           | ""             | '{"build":{"type":null},"scm":{"type":null},"ci":{"type":null},"environmentVariables":[{"key":"mykey1","value":"myvalue1"},{"key":"mykey2","value":"myvalue2"}],"systemProperties":[{"key":"java.runtime.name","value":"OpenJDK"},{"key":"java.version","value":"1.8.0_181"},{"key":"java.vm.vendor","value":""}],"javaVersion":"1.8.0_181","detailedJavaVersion":"OpenJDK 1.8.0_181"}'
+        "is case insensitive for openjdk" | "1.8.0_181" | "openjdk"                           | ""             | '{"build":{"type":null},"scm":{"type":null},"ci":{"type":null},"environmentVariables":[{"key":"mykey1","value":"myvalue1"},{"key":"mykey2","value":"myvalue2"}],"systemProperties":[{"key":"java.runtime.name","value":"openjdk"},{"key":"java.version","value":"1.8.0_181"},{"key":"java.vm.vendor","value":""}],"javaVersion":"1.8.0_181","detailedJavaVersion":"OpenJDK 1.8.0_181"}'
     }
 }

--- a/src/test/groovy/nebula/plugin/metrics/model/InfoTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/model/InfoTest.groovy
@@ -65,7 +65,6 @@ class InfoTest extends Specification {
         expect:
         mapper.writeValueAsString(info) == expectedResult
 
-        
         where:
         description                       | version     | runtimeName                         | vendor         | expectedResult
         "is Oracle"                       | "1.8.0_181" | "Oracle"                            | ""             | '{"build":{"type":null},"scm":{"type":null},"ci":{"type":null},"environmentVariables":[{"key":"mykey1","value":"myvalue1"},{"key":"mykey2","value":"myvalue2"}],"systemProperties":[{"key":"java.runtime.name","value":"Oracle"},{"key":"java.version","value":"1.8.0_181"},{"key":"java.vm.vendor","value":""}],"javaVersion":"1.8.0_181","detailedJavaVersion":"Oracle 1.8.0_181"}'

--- a/src/test/groovy/nebula/plugin/metrics/model/InfoTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/model/InfoTest.groovy
@@ -65,6 +65,7 @@ class InfoTest extends Specification {
         expect:
         mapper.writeValueAsString(info) == expectedResult
 
+        
         where:
         description                       | version     | runtimeName                         | vendor         | expectedResult
         "is Oracle"                       | "1.8.0_181" | "Oracle"                            | ""             | '{"build":{"type":null},"scm":{"type":null},"ci":{"type":null},"environmentVariables":[{"key":"mykey1","value":"myvalue1"},{"key":"mykey2","value":"myvalue2"}],"systemProperties":[{"key":"java.runtime.name","value":"Oracle"},{"key":"java.version","value":"1.8.0_181"},{"key":"java.vm.vendor","value":""}],"javaVersion":"1.8.0_181","detailedJavaVersion":"Oracle 1.8.0_181"}'


### PR DESCRIPTION
This introduces a new element `detailedJavaVersion`

To prevent breaking existing users with `javaVersion`, I thought it would be better to introduce a new label for information.

The purpose of this element is to show the java version not only as `1.8.0_181` but as:

`Oracle 1.8.0_181`
`OpenJDK 1.8.0_181`

and so on...

In the case of OpenJDK, I added a special case. If the vendor is Azul, this adds the `zulu` suffix to the version. Example:

`Oracle 1.8.0_181-zulu`

Naming is hard, so if you have a better name for `detailedJavaVersion`, I'll be more than happy to change it
