### PR TITLE
stop using BuildCompletionListener since it is an internal api

### DIFF
--- a/src/main/java/nebula/plugin/metrics/collector/GradleBuildMetricsCollector.java
+++ b/src/main/java/nebula/plugin/metrics/collector/GradleBuildMetricsCollector.java
@@ -46,7 +46,6 @@ import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.TaskState;
-import org.gradle.initialization.BuildCompletionListener;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 
@@ -59,7 +58,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
-public final class GradleBuildMetricsCollector implements BuildListener, ProjectEvaluationListener, TaskExecutionListener, DependencyResolutionListener, BuildCompletionListener {
+public final class GradleBuildMetricsCollector implements BuildListener, ProjectEvaluationListener, TaskExecutionListener, DependencyResolutionListener {
 
     private static final long TIMEOUT_MS = 5000;
 
@@ -107,18 +106,6 @@ public final class GradleBuildMetricsCollector implements BuildListener, Project
     public void projectsLoaded(Gradle gradle) {
         checkNotNull(gradle);
         buildMetrics.setProjectsLoaded(clock.getCurrentTime());
-    }
-
-    @Override
-    public void completed() {
-        if (buildMetrics != null) {
-            buildMetrics.setBuildFinished(clock.getCurrentTime());
-            try {
-                buildFinished(buildMetrics);
-            } finally {
-                buildMetrics = null;
-            }
-        }
     }
 
     // ProjectEvaluationListener
@@ -241,7 +228,10 @@ public final class GradleBuildMetricsCollector implements BuildListener, Project
 
     @Override
     public void buildFinished(BuildResult result) {
+        buildMetrics.setBuildFinished(clock.getCurrentTime());
+        buildFinished(buildMetrics);
         buildMetrics.setSuccessful(result.getFailure() == null);
+        buildMetrics = null;
     }
 
     public void buildFinished(BuildMetrics result) {

--- a/src/test/groovy/nebula/plugin/metrics/MetricsPluginTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/MetricsPluginTest.groovy
@@ -17,6 +17,8 @@
 
 package nebula.plugin.metrics
 
+import com.google.common.base.Optional
+import com.google.common.util.concurrent.Service
 import nebula.plugin.metrics.dispatcher.MetricsDispatcher
 import nebula.test.ProjectSpec
 import org.gradle.BuildListener
@@ -27,6 +29,9 @@ import org.gradle.api.internal.project.DefaultProject
 import org.gradle.invocation.DefaultGradle
 
 class MetricsPluginTest extends ProjectSpec {
+
+    def mockService = Mock(Service)
+
     def 'plugin can only be applied to root project'() {
         given:
         def subproject = addSubproject('subproject')
@@ -44,6 +49,8 @@ class MetricsPluginTest extends ProjectSpec {
             dispatcher.isRunning() >> true
             dispatcher
         }
+        1 * dispatcher.stopAsync() >> mockService
+        1 * dispatcher.receipt() >> Optional.of("")
 
         DefaultGradle gradle = project.gradle
 
@@ -66,6 +73,8 @@ class MetricsPluginTest extends ProjectSpec {
 
         then:
         1 * dispatcher.result(_)
+        1 * dispatcher.stopAsync() >> mockService
+        1 * dispatcher.receipt() >> Optional.of("")
     }
 
     BuildListener buildListenerBroadcaster(Project project) {


### PR DESCRIPTION
Turns out `org.gradle.initialization.BuildCompletionListener` is not a public API.

This pull request is to stop using it and only rely on `buildFinished` from `BuildListener`

