### PR TITLE
Add support for regex in sanitized properties

### DIFF
--- a/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
@@ -64,6 +64,7 @@ public class MetricsPluginExtension {
 
     private DispatcherType dispatcherType = DispatcherType.ES_HTTP;
     private List<String> sanitizedProperties = new ArrayList<>();
+    private String sanitizedPropertiesRegex;
     private boolean failOnError = true;
     private boolean verboseErrorOutput = false;
 
@@ -142,6 +143,15 @@ public class MetricsPluginExtension {
 
     public void setSanitizedProperties(List<String> sanitizedProperties) {
         this.sanitizedProperties = checkNotNull(sanitizedProperties);
+    }
+
+
+    public String getSanitizedPropertiesRegex() {
+        return sanitizedPropertiesRegex;
+    }
+
+    public void setSanitizedPropertiesRegex(String sanitizedPropertiesRegex) {
+        this.sanitizedPropertiesRegex = sanitizedPropertiesRegex;
     }
 
     public String getRestLogEventName() {

--- a/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
@@ -64,7 +64,7 @@ public class MetricsPluginExtension {
 
     private DispatcherType dispatcherType = DispatcherType.ES_HTTP;
     private List<String> sanitizedProperties = new ArrayList<>();
-    private String sanitizedPropertiesRegex;
+    private String sanitizedPropertiesRegex = "(?i).*_(TOKEN|KEY|SECRET|PASSWORD)$";
     private boolean failOnError = true;
     private boolean verboseErrorOutput = false;
 

--- a/src/main/java/nebula/plugin/metrics/dispatcher/AbstractMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/AbstractMetricsDispatcher.java
@@ -180,11 +180,7 @@ public abstract class AbstractMetricsDispatcher extends AbstractQueuedExecutionT
     private void sanitizeProperties(Build build) {
         Info info = build.getInfo();
         if (info != null) {
-            if(extension.getSanitizedPropertiesRegex() != null) {
-                build.setInfo(Info.sanitize(info, extension.getSanitizedPropertiesRegex()));
-            } else {
-                build.setInfo(Info.sanitize(info, extension.getSanitizedProperties()));
-            }
+            build.setInfo(Info.sanitize(info, extension.getSanitizedProperties(), extension.getSanitizedPropertiesRegex()));
         }
     }
 

--- a/src/main/java/nebula/plugin/metrics/dispatcher/AbstractMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/AbstractMetricsDispatcher.java
@@ -180,7 +180,11 @@ public abstract class AbstractMetricsDispatcher extends AbstractQueuedExecutionT
     private void sanitizeProperties(Build build) {
         Info info = build.getInfo();
         if (info != null) {
-            build.setInfo(Info.sanitize(info, extension.getSanitizedProperties()));
+            if(extension.getSanitizedPropertiesRegex() != null) {
+                build.setInfo(Info.sanitize(info, extension.getSanitizedPropertiesRegex()));
+            } else {
+                build.setInfo(Info.sanitize(info, extension.getSanitizedProperties()));
+            }
         }
     }
 

--- a/src/main/java/nebula/plugin/metrics/model/Info.java
+++ b/src/main/java/nebula/plugin/metrics/model/Info.java
@@ -57,32 +57,16 @@ public class Info {
         return new Info(tool, scm, ci, envList, systemPropertiesList);
     }
 
-    public static Info sanitize(Info info, List<String> sanitizedProperties) {
-        return new Info(info.getBuild(), info.getScm(), info.getCi(), sanitizeKeyValues(info.getEnvironmentVariables(), sanitizedProperties), sanitizeKeyValues(info.getSystemProperties(), sanitizedProperties));
-    }
-
-    public static Info sanitize(Info info, String sanitizedPropertiesRegex) {
+    public static Info sanitize(Info info, List<String> sanitizedProperties, String sanitizedPropertiesRegex) {
         Pattern sanitizedPropertiesPattern = Pattern.compile(sanitizedPropertiesRegex);
-        return new Info(info.getBuild(), info.getScm(), info.getCi(), sanitizeKeyValues(info.getEnvironmentVariables(), sanitizedPropertiesPattern), sanitizeKeyValues(info.getSystemProperties(), sanitizedPropertiesPattern));
+        return new Info(info.getBuild(), info.getScm(), info.getCi(), sanitizeKeyValues(info.getEnvironmentVariables(), sanitizedProperties, sanitizedPropertiesPattern), sanitizeKeyValues(info.getSystemProperties(), sanitizedProperties, sanitizedPropertiesPattern));
     }
 
-    private static List<KeyValue> sanitizeKeyValues(List<KeyValue> keyValues, List<String> sanitizedProperties) {
-        List<KeyValue> sanitizedKeyValues = new ArrayList<>();
-        for (KeyValue keyValue : keyValues) {
-            if (sanitizedProperties.contains(keyValue.getKey()) ) {
-                sanitizedKeyValues.add(new KeyValue(keyValue.getKey(), SANITIZED));
-            } else {
-                sanitizedKeyValues.add(keyValue);
-            }
-        }
-        return sanitizedKeyValues;
-    }
-
-    private static List<KeyValue> sanitizeKeyValues(List<KeyValue> keyValues, Pattern sanitizedPropertiesPattern) {
+    private static List<KeyValue> sanitizeKeyValues(List<KeyValue> keyValues, List<String> sanitizedProperties, Pattern sanitizedPropertiesPattern) {
         List<KeyValue> sanitizedKeyValues = new ArrayList<>();
         for (KeyValue keyValue : keyValues) {
             Matcher m = sanitizedPropertiesPattern.matcher(keyValue.getKey());
-            if (m.matches()) {
+            if (sanitizedProperties.contains(keyValue.getKey()) || m.matches()) {
                 sanitizedKeyValues.add(new KeyValue(keyValue.getKey(), SANITIZED));
             } else {
                 sanitizedKeyValues.add(keyValue);

--- a/src/test/groovy/nebula/plugin/metrics/model/InfoTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/model/InfoTest.groovy
@@ -43,9 +43,10 @@ class InfoTest extends Specification {
         map.put("mykey2", "myvalue2")
         def tool = Mock(Tool)
         def info = Info.create(tool, tool, tool, Collections.emptyMap(), map)
+        String regex = "(?i).*\\_(TOKEN|KEY|SECRET|PASSWORD)\$"
 
         expect:
-        def sanitizedInfo = Info.sanitize(info, Arrays.asList("mykey1"))
+        def sanitizedInfo = Info.sanitize(info, Arrays.asList("mykey1"), regex)
         sanitizedInfo.systemProperties.find { it.key == "mykey1" }.value == "SANITIZED"
     }
 
@@ -61,7 +62,7 @@ class InfoTest extends Specification {
 
         when:
         String regex = "(?i).*\\_(TOKEN|KEY|SECRET|PASSWORD)\$"
-        def sanitizedInfo = Info.sanitize(info, regex)
+        def sanitizedInfo = Info.sanitize(info, Arrays.asList("mykey1"), regex)
 
         then:
         sanitizedInfo.systemProperties.find { it.key == "MY_TOKEN" }.value == "SANITIZED"


### PR DESCRIPTION
Current support is for a list of properties to sanitize before pushing metrics, either to elastic or splunk or something else.

This change introduces support for regex via `sanitizedPropertiesRegex`

By doing something like:

```
metrics {
     sanitizedPropertiesRegex = "(?i).*\\_(TOKEN|KEY|SECRET|PASSWORD)\$"
}
```

we can sanitize keys that end with tokes suffixes. Ex. `MY_TOKEN`.