### PR TITLE
allow to provide a custom metrics dispatcher

### DIFF
--- a/src/main/java/nebula/plugin/metrics/MetricsPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPlugin.java
@@ -137,12 +137,7 @@ public final class MetricsPlugin implements Plugin<Project> {
 
     }
 
-    public void addCustomDispatcher(MetricsDispatcher dispatcher) {
-        this.dispatcher = checkNotNull(dispatcher);
-    }
-
-    @VisibleForTesting
-    void setDispatcher(MetricsDispatcher dispatcher) {
+    public void setDispatcher(MetricsDispatcher dispatcher) {
         this.dispatcher = checkNotNull(dispatcher);
     }
 

--- a/src/main/java/nebula/plugin/metrics/MetricsPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPlugin.java
@@ -30,6 +30,7 @@ import nebula.plugin.metrics.time.MonotonicClock;
 import org.gradle.BuildResult;
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
+import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -122,6 +123,12 @@ public final class MetricsPlugin implements Plugin<Project> {
                             dispatcher = new NoopMetricsDispatcher(extension);
                             break;
                         }
+                        case CUSTOM: {
+                            if(dispatcher instanceof UninitializedMetricsDispatcher) {
+                                throw new GradleException("addCustomDispatcher should be called to set dispatcher when CUSTOM is selected as type");
+                            }
+                            break;
+                        }
                     }
                 }
                 configureProjectCollectors(project.getAllprojects());
@@ -130,9 +137,18 @@ public final class MetricsPlugin implements Plugin<Project> {
 
     }
 
+    public void addCustomDispatcher(MetricsDispatcher dispatcher) {
+        this.dispatcher = checkNotNull(dispatcher);
+    }
+
     @VisibleForTesting
     void setDispatcher(MetricsDispatcher dispatcher) {
         this.dispatcher = checkNotNull(dispatcher);
+    }
+
+    @VisibleForTesting
+    MetricsDispatcher getDispatcher() {
+        return dispatcher;
     }
 
     private void configureRootProjectCollectors(Project rootProject, BuildStartedTime buildStartedTime) {

--- a/src/main/java/nebula/plugin/metrics/MetricsPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPlugin.java
@@ -125,7 +125,7 @@ public final class MetricsPlugin implements Plugin<Project> {
                         }
                         case CUSTOM: {
                             if(dispatcher instanceof UninitializedMetricsDispatcher) {
-                                throw new GradleException("addCustomDispatcher should be called to set dispatcher when CUSTOM is selected as type");
+                                throw new GradleException("setDispatcher should be called to set dispatcher when CUSTOM is selected as type");
                             }
                             break;
                         }

--- a/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
@@ -239,6 +239,7 @@ public class MetricsPluginExtension {
         ES_HTTP,
         SPLUNK,
         REST,
-        NOOP
+        NOOP,
+        CUSTOM
     }
 }

--- a/src/test/groovy/nebula/plugin/metrics/CustomMetricsDispatcherTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/CustomMetricsDispatcherTest.groovy
@@ -51,7 +51,7 @@ class CustomMetricsDispatcherTest extends ProjectSpec {
 
         when:
         metricsPluginExtension.dispatcherType = MetricsPluginExtension.DispatcherType.CUSTOM
-        plugin.addCustomDispatcher(myCustomMetricsDispatcher)
+        plugin.setDispatcher(myCustomMetricsDispatcher)
 
         and:
         def defaultProject = ((DefaultProject) project)

--- a/src/test/groovy/nebula/plugin/metrics/CustomMetricsDispatcherTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/CustomMetricsDispatcherTest.groovy
@@ -39,7 +39,7 @@ class CustomMetricsDispatcherTest extends ProjectSpec {
 
         then:
         GradleException e = thrown(GradleException)
-        e.message == 'addCustomDispatcher should be called to set dispatcher when CUSTOM is selected as type'
+        e.message == 'setDispatcher should be called to set dispatcher when CUSTOM is selected as type'
     }
 
     def 'should evaluate project if CUSTOM dispatcher is provided'() {

--- a/src/test/groovy/nebula/plugin/metrics/CustomMetricsDispatcherTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/CustomMetricsDispatcherTest.groovy
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2015-2018 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package nebula.plugin.metrics
+
+import com.google.common.base.Optional
+import nebula.plugin.metrics.dispatcher.AbstractMetricsDispatcher
+import nebula.test.ProjectSpec
+import org.gradle.api.GradleException
+import org.gradle.api.internal.project.DefaultProject
+
+class CustomMetricsDispatcherTest extends ProjectSpec {
+
+    def 'should fail to evaluate project if CUSTOM dispatcher and not provided'() {
+        setup:
+        project.plugins.apply(MetricsPlugin)
+        def metricsPluginExtension = project.extensions.findByName(MetricsPluginExtension.METRICS_EXTENSION_NAME)
+
+        when:
+        metricsPluginExtension.dispatcherType = MetricsPluginExtension.DispatcherType.CUSTOM
+
+        and:
+        def defaultProject = ((DefaultProject) project)
+        defaultProject.getProjectEvaluationBroadcaster().afterEvaluate(project, project.getState())
+
+        then:
+        GradleException e = thrown(GradleException)
+        e.message == 'addCustomDispatcher should be called to set dispatcher when CUSTOM is selected as type'
+    }
+
+    def 'should evaluate project if CUSTOM dispatcher is provided'() {
+        setup:
+        project.plugins.apply(MetricsPlugin)
+        def metricsPluginExtension = project.extensions.findByName(MetricsPluginExtension.METRICS_EXTENSION_NAME)
+        def plugin = project.plugins.getPlugin(MetricsPlugin)
+        MyCustomMetricsDispatcher myCustomMetricsDispatcher = new MyCustomMetricsDispatcher(metricsPluginExtension as MetricsPluginExtension)
+
+        when:
+        metricsPluginExtension.dispatcherType = MetricsPluginExtension.DispatcherType.CUSTOM
+        plugin.addCustomDispatcher(myCustomMetricsDispatcher)
+
+        and:
+        def defaultProject = ((DefaultProject) project)
+        defaultProject.getProjectEvaluationBroadcaster().afterEvaluate(project, project.getState())
+
+        then:
+        notThrown(GradleException)
+        plugin.dispatcher instanceof MyCustomMetricsDispatcher
+    }
+
+
+    private class MyCustomMetricsDispatcher extends AbstractMetricsDispatcher {
+
+         MyCustomMetricsDispatcher(MetricsPluginExtension extension) {
+            super(extension, false)
+        }
+
+        @Override
+        protected String getCollectionName() {
+            return null
+        }
+
+        @Override
+        protected String index(String indexName, String type, String source, Optional<String> id) {
+            return null
+        }
+
+        @Override
+        protected void bulkIndex(String indexName, String type, Collection<String> sources) {
+
+        }
+    }
+}


### PR DESCRIPTION
The idea for this is to provide a custom metrics dispatcher. Our use case: keystone

Usage is:

```
 metrics {
                dispatcherType = 'CUSTOM'
}
```

and programatically, we could add a custom one:

```groovy
project.plugins.apply(MetricsPlugin)
def metricsPluginExtension = project.extensions.findByName(MetricsPluginExtension.METRICS_EXTENSION_NAME)
def plugin = project.plugins.getPlugin(MetricsPlugin)
MyCustomMetricsDispatcher myCustomMetricsDispatcher = new MyCustomMetricsDispatcher(metricsPluginExtension as MetricsPluginExtension)


metricsPluginExtension.dispatcherType = MetricsPluginExtension.DispatcherType.CUSTOM
plugin.addCustomDispatcher(myCustomMetricsDispatcher)
```