### PR TITLE
Add a way of adding a full URI for elasticsearch

### DIFF
--- a/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
@@ -43,7 +43,7 @@ public class MetricsPluginExtension {
 
     public static final String DEFAULT_INDEX_NAME = "default";
 
-    private String esURI = null;
+    private String fullURI = null;
     private String hostname = "localhost";
     private int transportPort = 9300;
     private int httpPort = 9200;
@@ -76,12 +76,12 @@ public class MetricsPluginExtension {
         this.hostname = checkNotNull(hostname);
     }
 
-    public String getEsURI() {
-        return esURI;
+    public String getFullURI() {
+        return fullURI;
     }
 
-    public void setEsURI(String esURI) {
-        this.esURI = esURI;
+    public void setFullURI(String fullURI) {
+        this.fullURI = fullURI;
     }
 
     public String getEsBasicAuthUsername() {

--- a/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPluginExtension.java
@@ -17,7 +17,6 @@
 
 package nebula.plugin.metrics;
 
-import org.gradle.api.logging.LogLevel;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -44,6 +43,7 @@ public class MetricsPluginExtension {
 
     public static final String DEFAULT_INDEX_NAME = "default";
 
+    private String esURI = null;
     private String hostname = "localhost";
     private int transportPort = 9300;
     private int httpPort = 9200;
@@ -74,6 +74,14 @@ public class MetricsPluginExtension {
 
     public void setHostname(String hostname) {
         this.hostname = checkNotNull(hostname);
+    }
+
+    public String getEsURI() {
+        return esURI;
+    }
+
+    public void setEsURI(String esURI) {
+        this.esURI = esURI;
     }
 
     public String getEsBasicAuthUsername() {

--- a/src/main/java/nebula/plugin/metrics/dispatcher/AbstractESMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/AbstractESMetricsDispatcher.java
@@ -17,10 +17,8 @@
 
 package nebula.plugin.metrics.dispatcher;
 
-import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import ch.qos.logback.classic.spi.LoggingEvent;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
@@ -31,14 +29,15 @@ import net.logstash.logback.composite.JsonProviders;
 import net.logstash.logback.composite.loggingevent.MdcJsonProvider;
 import net.logstash.logback.layout.LogstashLayout;
 import org.apache.commons.io.IOUtils;
-import org.gradle.internal.logging.events.LogEvent;
 import org.slf4j.Logger;
 
-import java.io.*;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 public abstract class AbstractESMetricsDispatcher extends AbstractMetricsDispatcher {
@@ -94,7 +93,7 @@ public abstract class AbstractESMetricsDispatcher extends AbstractMetricsDispatc
             String file = "/" + extension.getIndexName() + "/" + BUILD_TYPE + "/" + buildId.get();
             URL url;
             try {
-                url = new URL("http", extension.getHostname(), extension.getHttpPort(), file);
+                url = new URL(getURI(extension) + file);
             } catch (MalformedURLException e) {
                 throw Throwables.propagate(e);
             }
@@ -130,6 +129,10 @@ public abstract class AbstractESMetricsDispatcher extends AbstractMetricsDispatc
     @Override
     protected String getCollectionName() {
         return extension.getIndexName();
+    }
+
+    protected String getURI(MetricsPluginExtension extension) {
+        return extension.getFullURI() != null ? extension.getFullURI() : "http://" + extension.getHostname() + ":" + extension.getHttpPort();
     }
 
     protected abstract void createIndex(String indexName, String source);

--- a/src/main/java/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcher.java
@@ -51,17 +51,13 @@ public final class HttpESMetricsDispatcher extends AbstractESMetricsDispatcher {
     protected void startUpClient() {
         JestClientFactory factory = new JestClientFactory();
         HttpClientConfig.Builder config = new HttpClientConfig
-                .Builder(getESURI(this.extension))
+                .Builder(getURI(this.extension))
                 .multiThreaded(false);
         if (!Strings.isNullOrEmpty(extension.getEsBasicAuthUsername())) {
             config.defaultCredentials(extension.getEsBasicAuthUsername(), extension.getEsBasicAuthPassword());
         }
         factory.setHttpClientConfig(config.build());
         client = factory.getObject();
-    }
-
-    private String getESURI(MetricsPluginExtension extension) {
-        return extension.getEsURI() != null ? extension.getEsURI() : "http://" + extension.getHostname() + ":" + extension.getHttpPort();
     }
 
     @Override

--- a/src/main/java/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcher.java
@@ -51,13 +51,17 @@ public final class HttpESMetricsDispatcher extends AbstractESMetricsDispatcher {
     protected void startUpClient() {
         JestClientFactory factory = new JestClientFactory();
         HttpClientConfig.Builder config = new HttpClientConfig
-                .Builder("http://" + extension.getHostname() + ":" + extension.getHttpPort())
+                .Builder(getESURI(this.extension))
                 .multiThreaded(false);
         if (!Strings.isNullOrEmpty(extension.getEsBasicAuthUsername())) {
             config.defaultCredentials(extension.getEsBasicAuthUsername(), extension.getEsBasicAuthPassword());
         }
         factory.setHttpClientConfig(config.build());
         client = factory.getObject();
+    }
+
+    private String getESURI(MetricsPluginExtension extension) {
+        return extension.getEsURI() != null ? extension.getEsURI() : "http://" + extension.getHostname() + ":" + extension.getHttpPort();
     }
 
     @Override

--- a/src/test/groovy/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcherTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcherTest.groovy
@@ -62,8 +62,37 @@ class HttpESMetricsDispatcherTest extends Specification {
         where: basicAuth << [true, false]
     }
 
-    private static HttpServer createMockEsInstance(boolean basicAuth) {
-        HttpServer mockEsInstance = HttpServer.create(new InetSocketAddress(esPort), 0)
+    @Unroll
+    def "HttpESMetricsDispatcher should use full uri if configured: #fullUriPresent"(boolean fullUriPresent) {
+        given: 'running mock ES instance and HttpESMetricsDispatcher'
+        def port = fullUriPresent ? 1338 : esPort
+        HttpServer mockEsInstance = createMockEsInstance(false, port)
+        mockEsInstance.start()
+        MetricsPluginExtension metrics = new MetricsPluginExtension()
+        metrics.setHostname('localhost')
+        metrics.setHttpPort(esPort)
+        metrics.setIndexName('index')
+        if (fullUriPresent) {
+            metrics.setEsURI("http://localhost:$port")
+        }
+        HttpESMetricsDispatcher dispatcher = new HttpESMetricsDispatcher(metrics)
+        dispatcher.startAsync().awaitRunning()
+
+        when: 'dispatcher tries to create an index'
+        def indexExists = dispatcher.exists('index')
+
+        then: 'request should succeed, and we should see a valid response'
+        noExceptionThrown()
+        indexExists
+
+        cleanup:
+        mockEsInstance?.stop(0)
+
+        where: fullUriPresent << [true, false]
+    }
+
+    private static HttpServer createMockEsInstance(boolean basicAuth, int port = esPort) {
+        HttpServer mockEsInstance = HttpServer.create(new InetSocketAddress(port), 0)
         HttpContext rootCtx = mockEsInstance.createContext(context, buildEsHttpHandler())
         if (basicAuth) {
             rootCtx.setAuthenticator(new BasicAuthenticator(context) {

--- a/src/test/groovy/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcherTest.groovy
+++ b/src/test/groovy/nebula/plugin/metrics/dispatcher/HttpESMetricsDispatcherTest.groovy
@@ -73,7 +73,7 @@ class HttpESMetricsDispatcherTest extends Specification {
         metrics.setHttpPort(esPort)
         metrics.setIndexName('index')
         if (fullUriPresent) {
-            metrics.setEsURI("http://localhost:$port")
+            metrics.setFullURI("http://localhost:$port")
         }
         HttpESMetricsDispatcher dispatcher = new HttpESMetricsDispatcher(metrics)
         dispatcher.startAsync().awaitRunning()


### PR DESCRIPTION
The ES cluster that I want to send metrics to is behind a custom DNS, that already resolves the port for me. I needed a way of providing the full ES uri to the dispatcher, this is what this PR does