### PR TITLE
Adds "info" on index creation on ES

### DIFF
--- a/src/main/java/nebula/plugin/metrics/dispatcher/AbstractMetricsDispatcher.java
+++ b/src/main/java/nebula/plugin/metrics/dispatcher/AbstractMetricsDispatcher.java
@@ -186,6 +186,8 @@ public abstract class AbstractMetricsDispatcher extends AbstractQueuedExecutionT
         Info info = build.getInfo();
         if (info != null) {
             build.setInfo(Info.sanitize(info, extension.getSanitizedProperties(), extension.getSanitizedPropertiesRegex()));
+        } else {
+            build.setInfo(Info.create());
         }
     }
 

--- a/src/main/java/nebula/plugin/metrics/model/Info.java
+++ b/src/main/java/nebula/plugin/metrics/model/Info.java
@@ -43,6 +43,8 @@ public class Info {
     private static final String SPACE = " ";
     private static final String SANITIZED = "SANITIZED";
 
+    public static Info create() { return create(new UnknownTool(), new UnknownTool(), new UnknownTool()); }
+    
     public static Info create(GradleToolContainer tool) {
         return create(tool, new UnknownTool(), new UnknownTool());
     }


### PR DESCRIPTION
If the "info" array isn't added, the index wouldn't be updated on ES on build finished.

The json posted on first PUT:
```json
{
  "events": [],
  "tasks": [],
  "tests": [],
  "result": {
    "status": "unknown"
  },
  "startTime": "2019-08-19T14:05:36.049Z",
  "elapsedTime": 0,
  "eventsCount": 0,
  "eventsElapsedTime": 0,
  "tasksElapsedTime": 0,
  "testElapsedTime": 0,
  "finishedTime": "2019-08-19T14:05:36.049Z",
  "testCount": 0,
  "taskCount": 0
}
```

So I would get a `HTTP/1.1 400 Bad Request` when posting the json on buildFinished.

This just adds a dummy Info on first put