### PR TITLE
Support for settings evaluation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,9 @@ pluginBundle {
             tags = ['nebula', 'metrics']
         }
 
-        metricsGradle {
-            id = 'nebula.metrics.gradle-plugin'
-            displayName = 'Gradle Metrics Gradle plugin'
+        metricsInit {
+            id = 'nebula.metrics.init-plugin'
+            displayName = 'Gradle Metrics Init plugin'
             description = project.description
             tags = ['nebula', 'metrics']
         }

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply from: 'gradle/tests.gradle'
 apply from: 'gradle/idea.gradle'
 apply from: 'gradle/dependencies.gradle'
 
-description 'Gradle metrics plugin'
+description 'Gradle Metrics plugin: Collects gradle metrics and publishes to ElasticSearch HTTP/Splunk/REST endpoints'
 
 lombok {
     version = '1.18.10'
@@ -46,10 +46,28 @@ contacts {
 }
 
 pluginBundle {
+    website = 'https://github.com/nebula-plugins/gradle-metrics-plugin'
+    vcsUrl = 'https://github.com/nebula-plugins/gradle-metrics-plugin.git'
+    description = 'Gradle Metrics plugin: Collects gradle metrics and publishes to ElasticSearch HTTP/Splunk/REST endpoints'
+
     plugins {
         metrics {
             id = 'nebula.metrics'
             displayName = 'Gradle Metrics plugin'
+            description = project.description
+            tags = ['nebula', 'metrics']
+        }
+
+        metricsSettings {
+            id = 'nebula.metrics.settings-plugin'
+            displayName = 'Gradle Metrics Settings plugin'
+            description = project.description
+            tags = ['nebula', 'metrics']
+        }
+
+        metricsGradle {
+            id = 'nebula.metrics.gradle-plugin'
+            displayName = 'Gradle Metrics Gradle plugin'
             description = project.description
             tags = ['nebula', 'metrics']
         }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -59,7 +59,7 @@ dependencies {
     plugin 'org.apache.commons:commons-lang3:3.4' // also transitive of Jest
     plugin 'commons-io:commons-io:2.5'
 
-    plugin 'com.netflix.nebula:gradle-info-plugin:4.+', optional
+    plugin 'com.netflix.nebula:gradle-info-plugin:latest.release', optional
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.0'
 

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -20,8 +20,8 @@ com.jcraft:jsch.agentproxy.usocket-jna:0.0.7
 com.jcraft:jsch.agentproxy.usocket-nc:0.0.7
 com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
-com.netflix.nebula:gradle-contacts-plugin:4.0.2
-com.netflix.nebula:gradle-info-plugin:4.0.3
+com.netflix.nebula:gradle-contacts-plugin:5.1.0
+com.netflix.nebula:gradle-info-plugin:7.1.4
 com.perforce:p4java:2015.2.1365273
 com.spatial4j:spatial4j:0.4.1
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/gradle/dependency-locks/integTestCompileClasspath.lockfile
+++ b/gradle/dependency-locks/integTestCompileClasspath.lockfile
@@ -27,8 +27,8 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.kohlschutter.junixsocket:junixsocket-common:2.0.4
 com.kohlschutter.junixsocket:junixsocket-native-common:2.0.4
-com.netflix.nebula:gradle-contacts-plugin:4.0.2
-com.netflix.nebula:gradle-info-plugin:4.0.3
+com.netflix.nebula:gradle-contacts-plugin:5.1.0
+com.netflix.nebula:gradle-info-plugin:7.1.4
 com.netflix.nebula:nebula-test:7.8.6
 com.perforce:p4java:2015.2.1365273
 com.spatial4j:spatial4j:0.4.1

--- a/gradle/dependency-locks/integTestRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/integTestRuntimeClasspath.lockfile
@@ -27,8 +27,8 @@ com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
 com.kohlschutter.junixsocket:junixsocket-common:2.0.4
 com.kohlschutter.junixsocket:junixsocket-native-common:2.0.4
-com.netflix.nebula:gradle-contacts-plugin:4.0.2
-com.netflix.nebula:gradle-info-plugin:4.0.3
+com.netflix.nebula:gradle-contacts-plugin:5.1.0
+com.netflix.nebula:gradle-info-plugin:7.1.4
 com.netflix.nebula:nebula-test:7.8.6
 com.perforce:p4java:2015.2.1365273
 com.spatial4j:spatial4j:0.4.1

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -19,8 +19,8 @@ com.jcraft:jsch.agentproxy.usocket-jna:0.0.7
 com.jcraft:jsch.agentproxy.usocket-nc:0.0.7
 com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
-com.netflix.nebula:gradle-contacts-plugin:4.0.2
-com.netflix.nebula:gradle-info-plugin:4.0.3
+com.netflix.nebula:gradle-contacts-plugin:5.1.0
+com.netflix.nebula:gradle-info-plugin:7.1.4
 com.perforce:p4java:2015.2.1365273
 com.spatial4j:spatial4j:0.4.1
 com.trilead:trilead-ssh2:1.0.0-build220

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -24,8 +24,8 @@ com.jcraft:jsch.agentproxy.usocket-jna:0.0.7
 com.jcraft:jsch.agentproxy.usocket-nc:0.0.7
 com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
-com.netflix.nebula:gradle-contacts-plugin:4.0.2
-com.netflix.nebula:gradle-info-plugin:4.0.3
+com.netflix.nebula:gradle-contacts-plugin:5.1.0
+com.netflix.nebula:gradle-info-plugin:7.1.4
 com.netflix.nebula:nebula-test:7.8.6
 com.perforce:p4java:2015.2.1365273
 com.spatial4j:spatial4j:0.4.1

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -24,8 +24,8 @@ com.jcraft:jsch.agentproxy.usocket-jna:0.0.7
 com.jcraft:jsch.agentproxy.usocket-nc:0.0.7
 com.jcraft:jsch:0.1.54
 com.jcraft:jzlib:1.1.2
-com.netflix.nebula:gradle-contacts-plugin:4.0.2
-com.netflix.nebula:gradle-info-plugin:4.0.3
+com.netflix.nebula:gradle-contacts-plugin:5.1.0
+com.netflix.nebula:gradle-info-plugin:7.1.4
 com.netflix.nebula:nebula-test:7.8.6
 com.perforce:p4java:2015.2.1365273
 com.spatial4j:spatial4j:0.4.1

--- a/src/integTest/groovy/nebula/plugin/metrics/DependenciesBuilderWithClassesUnderTest.groovy
+++ b/src/integTest/groovy/nebula/plugin/metrics/DependenciesBuilderWithClassesUnderTest.groovy
@@ -1,0 +1,41 @@
+package nebula.plugin.metrics
+
+import com.google.common.base.Function
+import com.google.common.base.Predicate
+import com.google.common.collect.FluentIterable
+import nebula.test.functional.GradleRunner
+import org.gradle.internal.classloader.ClasspathUtil
+import org.gradle.internal.classpath.ClassPath
+import org.gradle.util.TextUtil
+
+class DependenciesBuilderWithClassesUnderTest {
+    static String buildDependencies() {
+        ClassLoader classLoader = DependenciesBuilderWithClassesUnderTest.class.getClassLoader()
+        def classpathFilter = GradleRunner.CLASSPATH_DEFAULT
+        getClasspathAsFiles(classLoader, classpathFilter).collect {
+            String.format("      classpath files('%s')\n", TextUtil.escapeString(it.getAbsolutePath()))
+        }.join('\n')
+    }
+
+    private static List<File> getClasspathAsFiles(ClassLoader classLoader, Predicate<URL> classpathFilter) {
+        List<URL> classpathUrls = getClasspathUrls(classLoader)
+        return FluentIterable.from(classpathUrls).filter(classpathFilter).transform(new Function<URL, File>() {
+            @Override
+            File apply(URL url) {
+                return new File(url.toURI())
+            }
+        }).toList()
+    }
+
+    private static List<URL> getClasspathUrls(ClassLoader classLoader) {
+        Object cp = ClasspathUtil.getClasspath(classLoader)
+        if (cp instanceof List<URL>) {
+            return (List<URL>) cp
+        }
+        if (cp instanceof ClassPath) { // introduced by gradle/gradle@0ab8bc2
+            return ((ClassPath) cp).asURLs
+        }
+        throw new IllegalStateException("Unable to extract classpath urls from type ${cp.class.canonicalName}")
+    }
+
+}

--- a/src/integTest/groovy/nebula/plugin/metrics/ESMetricsInitScriptIntegTest.groovy
+++ b/src/integTest/groovy/nebula/plugin/metrics/ESMetricsInitScriptIntegTest.groovy
@@ -1,49 +1,42 @@
-/*
- *  Copyright 2015-2019 Netflix, Inc.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- */
-
 package nebula.plugin.metrics
 
 import groovy.util.logging.Slf4j
-import nebula.plugin.metrics.MetricsPluginExtension.DispatcherType
 import nebula.test.IntegrationSpec
 import org.testcontainers.elasticsearch.ElasticsearchContainer
 import org.testcontainers.spock.Testcontainers
 import spock.lang.IgnoreIf
 import spock.lang.Shared
 
-/**
- * Integration tests for {@link MetricsPlugin}.
- */
 @Slf4j
 @Testcontainers
 @IgnoreIf({ Boolean.valueOf(env["NEBULA_IGNORE_TEST"]) })
-class ESMetricsPluginIntegTest extends IntegrationSpec {
-
+class ESMetricsInitScriptIntegTest extends IntegrationSpec {
 
     @Shared
     ElasticsearchContainer container = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:5.4.1")
 
+    def setup() {
+        File init = new File(projectDir, "init.gradle")
+        init.text = """
+            initscript {
+                dependencies {
+                   ${DependenciesBuilderWithClassesUnderTest.buildDependencies()}
+                }
+            }
+
+            apply plugin: nebula.plugin.metrics.MetricsGradlePlugin
+""".stripMargin()
+        addInitScript(init)
+        fork = false
+    }
+
     def 'running projects task causes no errors and the build id to standard out'() {
         setup:
-        setValidBuildFile(DispatcherType.ES_HTTP)
+        setValidBuildFile(MetricsPluginExtension.DispatcherType.ES_HTTP)
         def result
 
         when:
-        result = runTasksSuccessfully('projects')
+        result = runTasksSuccessfully('build')
 
         then:
         noExceptionThrown()
@@ -54,11 +47,11 @@ class ESMetricsPluginIntegTest extends IntegrationSpec {
 
     def 'running offline results in no metrics being recorded'() {
         setup:
-        setValidBuildFile(DispatcherType.ES_HTTP)
+        setValidBuildFile(MetricsPluginExtension.DispatcherType.ES_HTTP)
         def result
 
         when:
-        result = runTasksSuccessfully("--offline", "projects")
+        result = runTasksSuccessfully("--offline", "build")
 
         then:
         noExceptionThrown()
@@ -66,12 +59,9 @@ class ESMetricsPluginIntegTest extends IntegrationSpec {
     }
 
 
-    def setValidBuildFile(DispatcherType dispatcherType) {
+    def setValidBuildFile(MetricsPluginExtension.DispatcherType dispatcherType) {
         def build = """
-
         apply plugin: 'java'
-        apply plugin: "nebula.info"
-        ${applyPlugin(MetricsPlugin)}
 
         metrics {
             esBasicAuthUsername = 'elastic'
@@ -80,14 +70,6 @@ class ESMetricsPluginIntegTest extends IntegrationSpec {
             transportPort = ${container.tcpHost.port}
             clusterName = 'elasticsearch_mpit'
             dispatcherType = '$dispatcherType'
-        }
-        
-        repositories {
-            mavenCentral()
-        }
-        
-        dependencies {
-            implementation 'com.google.guava:guava:19.0'
         }
     """.stripIndent()
         buildFile << build

--- a/src/integTest/groovy/nebula/plugin/metrics/ESMetricsInitScriptIntegTest.groovy
+++ b/src/integTest/groovy/nebula/plugin/metrics/ESMetricsInitScriptIntegTest.groovy
@@ -24,7 +24,7 @@ class ESMetricsInitScriptIntegTest extends IntegrationSpec {
                 }
             }
 
-            apply plugin: nebula.plugin.metrics.MetricsGradlePlugin
+            apply plugin: nebula.plugin.metrics.MetricsInitPlugin
 """.stripMargin()
         addInitScript(init)
         fork = false
@@ -62,6 +62,18 @@ class ESMetricsInitScriptIntegTest extends IntegrationSpec {
     def setValidBuildFile(MetricsPluginExtension.DispatcherType dispatcherType) {
         def build = """
         apply plugin: 'java'
+        buildscript {
+          repositories {
+            maven {
+              url "https://plugins.gradle.org/m2/"
+            }
+          }
+          dependencies {
+            classpath "com.netflix.nebula:gradle-info-plugin:7.1.4"
+          }
+        }
+        
+        apply plugin: "nebula.info"
 
         metrics {
             esBasicAuthUsername = 'elastic'

--- a/src/integTest/groovy/nebula/plugin/metrics/RestMetricsInitScriptIntegrationTest.groovy
+++ b/src/integTest/groovy/nebula/plugin/metrics/RestMetricsInitScriptIntegrationTest.groovy
@@ -24,7 +24,7 @@ class RestMetricsInitScriptIntegrationTest extends IntegrationSpec {
                 }
             }
 
-            apply plugin: nebula.plugin.metrics.MetricsGradlePlugin
+            apply plugin: nebula.plugin.metrics.MetricsInitPlugin
 """.stripMargin()
         addInitScript(init)
     }

--- a/src/integTest/groovy/nebula/plugin/metrics/RestMetricsInitScriptIntegrationTest.groovy
+++ b/src/integTest/groovy/nebula/plugin/metrics/RestMetricsInitScriptIntegrationTest.groovy
@@ -1,20 +1,3 @@
-/*
- *  Copyright 2015-2019 Netflix, Inc.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- *
- */
-
 package nebula.plugin.metrics
 
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
@@ -22,24 +5,38 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule
 import nebula.test.IntegrationSpec
 import org.junit.Rule
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import static com.github.tomakehurst.wiremock.client.WireMock.containing
+import static com.github.tomakehurst.wiremock.client.WireMock.post
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor
 
-class RestMetricsIntegTest extends IntegrationSpec {
+class RestMetricsInitScriptIntegrationTest extends IntegrationSpec {
 
     @Rule
     WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.wireMockConfig().dynamicPort().dynamicPort())
 
-    def 'metrics posts data to preconfigured REST server'() {
+    def setup() {
+        File init = new File(projectDir, "init.gradle")
+        init.text = """
+            initscript {
+                dependencies {
+                   ${DependenciesBuilderWithClassesUnderTest.buildDependencies()}
+                }
+            }
+
+            apply plugin: nebula.plugin.metrics.MetricsGradlePlugin
+""".stripMargin()
+        addInitScript(init)
+    }
+
+    def 'plugin can be applied at init script level'() {
         setup:
         buildFile << """
-            ${applyPlugin(MetricsPlugin)}
-
-            metrics {
-                restUri = 'http://localhost:${wireMockRule.port()}/myserver'
-                dispatcherType = 'REST'
-            }
-        """.stripIndent()
-
+metrics {
+    restUri = 'http://localhost:${wireMockRule.port()}/myserver'
+    dispatcherType = 'REST'
+}
+"""
 
         //First post
         stubFor(post('/myserver')
@@ -49,7 +46,7 @@ class RestMetricsIntegTest extends IntegrationSpec {
                 .withRequestBody(containing("finishedTime"))
                 .withRequestBody(containing("elapsedTime"))
                 .willReturn(
-                aResponse().withStatus(200).withHeader('Content-Type', 'application/json')))
+                        aResponse().withStatus(200).withHeader('Content-Type', 'application/json')))
 
         //build is finished
         stubFor(post('/myserver')
@@ -61,13 +58,12 @@ class RestMetricsIntegTest extends IntegrationSpec {
                 .withRequestBody(containing("elapsedTime"))
                 .withRequestBody(containing("project\":{\"name\":\"${moduleName}\",\"version\":\"unspecified\"}"))
                 .willReturn(
-                aResponse().withStatus(200).withHeader('Content-Type', 'application/json')))
+                        aResponse().withStatus(200).withHeader('Content-Type', 'application/json')))
 
         when:
-        def result = runTasksSuccessfully('projects')
+        def result = runTasksSuccessfully('build')
 
         then:
         result.standardOutput.contains("Metrics have been posted to http://localhost:${wireMockRule.port()}/myserver")
     }
-
 }

--- a/src/main/java/nebula/plugin/metrics/AbstractMetricsPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/AbstractMetricsPlugin.java
@@ -1,0 +1,181 @@
+/*
+ *  Copyright 2020 Netflix, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package nebula.plugin.metrics;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
+import groovy.lang.Closure;
+import nebula.plugin.metrics.collector.GradleBuildMetricsCollector;
+import nebula.plugin.metrics.collector.GradleTestSuiteCollector;
+import nebula.plugin.metrics.dispatcher.*;
+import nebula.plugin.metrics.time.BuildStartedTime;
+import nebula.plugin.metrics.time.Clock;
+import nebula.plugin.metrics.time.MonotonicClock;
+import org.gradle.BuildResult;
+import org.gradle.StartParameter;
+import org.gradle.api.Action;
+import org.gradle.api.GradleException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.invocation.BuildInvocationDetails;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.tasks.testing.Test;
+
+import javax.inject.Inject;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+public abstract class AbstractMetricsPlugin<T> implements Plugin<T> {
+
+    private final BuildInvocationDetails buildInvocationDetails;
+
+    @Inject
+    public AbstractMetricsPlugin(BuildInvocationDetails buildInvocationDetails) {
+        this.buildInvocationDetails = buildInvocationDetails;
+    }
+
+    private MetricsDispatcher dispatcher = new UninitializedMetricsDispatcher();
+
+    private final Clock clock = new MonotonicClock();
+
+
+    private Action<Project> configureProjectCollectorAction = new Action<Project>() {
+        @Override
+        public void execute(Project p) {
+            p.getTasks().withType(Test.class).configureEach(test -> {
+                GradleTestSuiteCollector suiteCollector = new GradleTestSuiteCollector(dispatcherSupplier, test);
+                test.addTestListener(suiteCollector);
+            });
+        }
+    };
+
+    public void setDispatcher(MetricsDispatcher dispatcher) {
+        this.dispatcher = checkNotNull(dispatcher);
+    }
+
+    @VisibleForTesting
+    MetricsDispatcher getDispatcher() {
+        return dispatcher;
+    }
+
+
+    /**
+     * Supplier allowing the dispatcher to be fetched lazily, so we can replace the instance for testing.
+     */
+    private Supplier<MetricsDispatcher> dispatcherSupplier = new Supplier<MetricsDispatcher>() {
+        @Override
+        public MetricsDispatcher get() {
+            return dispatcher;
+        }
+    };
+
+    public void configureProject(Project project) {
+        checkNotNull(project);
+
+        //Using internal API to retrieve build start time but still storing it in our own data structure
+        BuildStartedTime buildStartedTime = BuildStartedTime.startingAt(buildInvocationDetails.getBuildStartedTime());
+
+        checkState(project == project.getRootProject(), "The metrics plugin may only be applied to the root project");
+        ExtensionContainer extensions = project.getExtensions();
+        extensions.add("metrics", new MetricsPluginExtension());
+        Gradle gradle = project.getGradle();
+        StartParameter startParameter = gradle.getStartParameter();
+        final MetricsPluginExtension extension = extensions.getByType(MetricsPluginExtension.class);
+
+        if (project.hasProperty("metrics.enabled") && "false".equals(project.property("metrics.enabled"))) {
+            project.getLogger().warn("Metrics have been disabled for this build.");
+            return;
+        }
+
+        if (startParameter.isOffline()) {
+            project.getLogger().warn("Build is running offline. Metrics will not be collected.");
+            return;
+        }
+
+        configureRootProjectCollectors(project, buildStartedTime);
+        project.afterEvaluate(new Action<Project>() {
+            @Override
+            public void execute(Project project) {
+                if (dispatcher instanceof UninitializedMetricsDispatcher) {
+                    switch (extension.getDispatcherType()) {
+                        case ES_HTTP: {
+                            dispatcher = new HttpESMetricsDispatcher(extension);
+                            break;
+                        }
+                        case SPLUNK: {
+                            dispatcher = new SplunkMetricsDispatcher(extension);
+                            break;
+                        }
+                        case REST: {
+                            dispatcher = new RestMetricsDispatcher(extension);
+                            break;
+                        }
+                        case NOOP: {
+                            dispatcher = new NoopMetricsDispatcher(extension);
+                            break;
+                        }
+                        case CUSTOM: {
+                            if(dispatcher instanceof UninitializedMetricsDispatcher) {
+                                throw new GradleException("setDispatcher should be called to set dispatcher when CUSTOM is selected as type");
+                            }
+                            break;
+                        }
+                    }
+                }
+                configureProjectCollectors(project);
+            }
+        });
+    }
+
+
+    private void configureRootProjectCollectors(Project rootProject, BuildStartedTime buildStartedTime) {
+        final Gradle gradle = rootProject.getGradle();
+        final GradleBuildMetricsCollector gradleCollector = new GradleBuildMetricsCollector(dispatcherSupplier, buildStartedTime, gradle, clock);
+        gradle.addListener(gradleCollector);
+        gradle.projectsLoaded(new Closure(null) {
+            protected Object doCall(Object arguments) {
+                throw new RuntimeException("sdadsa");
+            }
+        });
+
+        gradle.settingsEvaluated(new Action<Settings>() {
+            @Override
+            public void execute(Settings settings) {
+                checkNotNull(settings);
+                gradleCollector.initializeBuildMetrics();
+                gradleCollector.getBuildMetrics().setSettingsEvaluated(clock.getCurrentTime());
+            }
+        });
+        gradle.buildFinished(new Closure(null) {
+            protected Object doCall(Object arguments) {
+                gradleCollector.buildFinishedClosure((BuildResult)arguments);
+                return null;
+            }
+        });
+    }
+
+    private void configureProjectCollectors(Project project) {
+        configureProjectCollectorAction.execute(project);
+        for (Project subproject : project.getSubprojects()) {
+            // perform task scan for subprojects after subproject evaluation
+            subproject.afterEvaluate(configureProjectCollectorAction);
+        }
+    }
+}

--- a/src/main/java/nebula/plugin/metrics/MetricsGradlePlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsGradlePlugin.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2015-2020 Netflix, Inc.
+ *  Copyright 2020 Netflix, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,25 +17,20 @@
 
 package nebula.plugin.metrics;
 
-import org.gradle.api.Project;
-
 import org.gradle.api.invocation.BuildInvocationDetails;
+import org.gradle.api.invocation.Gradle;
+
 import javax.inject.Inject;
 
-/**
- * Gradle build metrics plugin.
- *
- * @author Danny Thomas
- */
-public final class MetricsPlugin extends AbstractMetricsPlugin<Project> {
+public class MetricsGradlePlugin extends AbstractMetricsPlugin<Gradle> {
 
     @Inject
-    public MetricsPlugin(BuildInvocationDetails buildInvocationDetails) {
+    public MetricsGradlePlugin(BuildInvocationDetails buildInvocationDetails) {
         super(buildInvocationDetails);
     }
 
     @Override
-    public void apply(Project project) {
-        configureProject(project);
+    public void apply(Gradle gradle) {
+        configureProject(gradle.getRootProject());
     }
 }

--- a/src/main/java/nebula/plugin/metrics/MetricsGradlePlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsGradlePlugin.java
@@ -17,6 +17,8 @@
 
 package nebula.plugin.metrics;
 
+import nebula.plugin.metrics.model.BuildMetrics;
+
 import org.gradle.api.invocation.BuildInvocationDetails;
 import org.gradle.api.invocation.Gradle;
 
@@ -31,6 +33,15 @@ public class MetricsGradlePlugin extends AbstractMetricsPlugin<Gradle> {
 
     @Override
     public void apply(Gradle gradle) {
-        configureProject(gradle.getRootProject());
+        if(isOfflineMode(gradle)) {
+           gradle.rootProject(project -> {
+               createMetricsExtension(project);
+               project.getLogger().warn("Build is running offline. Metrics will not be collected.");
+           });
+            return;
+        }
+        BuildMetrics buildMetrics = initializeBuildMetrics(gradle);
+        createAndRegisterGradleBuildMetricsCollector(gradle, buildMetrics);
+        gradle.rootProject(this::configureProject);
     }
 }

--- a/src/main/java/nebula/plugin/metrics/MetricsInitPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsInitPlugin.java
@@ -17,8 +17,6 @@
 
 package nebula.plugin.metrics;
 
-import nebula.plugin.metrics.model.BuildMetrics;
-
 import org.gradle.api.invocation.BuildInvocationDetails;
 import org.gradle.api.invocation.Gradle;
 
@@ -33,15 +31,6 @@ public class MetricsInitPlugin extends AbstractMetricsPlugin<Gradle> {
 
     @Override
     public void apply(Gradle gradle) {
-        if(isOfflineMode(gradle)) {
-           gradle.rootProject(project -> {
-               createMetricsExtension(project);
-               project.getLogger().warn("Build is running offline. Metrics will not be collected.");
-           });
-            return;
-        }
-        BuildMetrics buildMetrics = initializeBuildMetrics(gradle);
-        createAndRegisterGradleBuildMetricsCollector(gradle, buildMetrics);
-        gradle.rootProject(this::configureProject);
+        applyToGradle(gradle);
     }
 }

--- a/src/main/java/nebula/plugin/metrics/MetricsInitPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsInitPlugin.java
@@ -24,10 +24,10 @@ import org.gradle.api.invocation.Gradle;
 
 import javax.inject.Inject;
 
-public class MetricsGradlePlugin extends AbstractMetricsPlugin<Gradle> {
+public class MetricsInitPlugin extends AbstractMetricsPlugin<Gradle> {
 
     @Inject
-    public MetricsGradlePlugin(BuildInvocationDetails buildInvocationDetails) {
+    public MetricsInitPlugin(BuildInvocationDetails buildInvocationDetails) {
         super(buildInvocationDetails);
     }
 

--- a/src/main/java/nebula/plugin/metrics/MetricsPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsPlugin.java
@@ -17,6 +17,7 @@
 
 package nebula.plugin.metrics;
 
+import nebula.plugin.metrics.model.BuildMetrics;
 import org.gradle.api.Project;
 
 import org.gradle.api.invocation.BuildInvocationDetails;
@@ -36,6 +37,13 @@ public final class MetricsPlugin extends AbstractMetricsPlugin<Project> {
 
     @Override
     public void apply(Project project) {
+        if(isOfflineMode(project.getGradle())) {
+            createMetricsExtension(project);
+            project.getLogger().warn("Build is running offline. Metrics will not be collected.");
+            return;
+        }
+        BuildMetrics buildMetrics = initializeBuildMetrics(project.getGradle());
+        createAndRegisterGradleBuildMetricsCollector(project.getGradle(), buildMetrics);
         configureProject(project);
     }
 }

--- a/src/main/java/nebula/plugin/metrics/MetricsSettingsPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsSettingsPlugin.java
@@ -17,7 +17,6 @@
 
 package nebula.plugin.metrics;
 
-import nebula.plugin.metrics.model.BuildMetrics;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.invocation.BuildInvocationDetails;
 import org.gradle.api.invocation.Gradle;
@@ -34,15 +33,6 @@ public class MetricsSettingsPlugin extends AbstractMetricsPlugin<Settings> {
     @Override
     public void apply(Settings settings) {
         Gradle gradle = settings.getGradle();
-        if(isOfflineMode(gradle)) {
-            gradle.rootProject(project -> {
-                createMetricsExtension(project);
-                project.getLogger().warn("Build is running offline. Metrics will not be collected.");
-            });
-            return;
-        }
-        BuildMetrics buildMetrics = initializeBuildMetrics(gradle);
-        createAndRegisterGradleBuildMetricsCollector(gradle, buildMetrics);
-        gradle.rootProject(this::configureProject);
+        applyToGradle(gradle);
     }
 }

--- a/src/main/java/nebula/plugin/metrics/MetricsSettingsPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsSettingsPlugin.java
@@ -17,8 +17,10 @@
 
 package nebula.plugin.metrics;
 
+import nebula.plugin.metrics.model.BuildMetrics;
 import org.gradle.api.initialization.Settings;
 import org.gradle.api.invocation.BuildInvocationDetails;
+import org.gradle.api.invocation.Gradle;
 
 import javax.inject.Inject;
 
@@ -31,6 +33,16 @@ public class MetricsSettingsPlugin extends AbstractMetricsPlugin<Settings> {
 
     @Override
     public void apply(Settings settings) {
-        configureProject(settings.getGradle().getRootProject());
+        Gradle gradle = settings.getGradle();
+        if(isOfflineMode(gradle)) {
+            gradle.rootProject(project -> {
+                createMetricsExtension(project);
+                project.getLogger().warn("Build is running offline. Metrics will not be collected.");
+            });
+            return;
+        }
+        BuildMetrics buildMetrics = initializeBuildMetrics(gradle);
+        createAndRegisterGradleBuildMetricsCollector(gradle, buildMetrics);
+        gradle.rootProject(this::configureProject);
     }
 }

--- a/src/main/java/nebula/plugin/metrics/MetricsSettingsPlugin.java
+++ b/src/main/java/nebula/plugin/metrics/MetricsSettingsPlugin.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2015-2020 Netflix, Inc.
+ *  Copyright 2020 Netflix, Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -17,25 +17,20 @@
 
 package nebula.plugin.metrics;
 
-import org.gradle.api.Project;
-
+import org.gradle.api.initialization.Settings;
 import org.gradle.api.invocation.BuildInvocationDetails;
+
 import javax.inject.Inject;
 
-/**
- * Gradle build metrics plugin.
- *
- * @author Danny Thomas
- */
-public final class MetricsPlugin extends AbstractMetricsPlugin<Project> {
+public class MetricsSettingsPlugin extends AbstractMetricsPlugin<Settings> {
 
     @Inject
-    public MetricsPlugin(BuildInvocationDetails buildInvocationDetails) {
+    public MetricsSettingsPlugin(BuildInvocationDetails buildInvocationDetails) {
         super(buildInvocationDetails);
     }
 
     @Override
-    public void apply(Project project) {
-        configureProject(project);
+    public void apply(Settings settings) {
+        configureProject(settings.getGradle().getRootProject());
     }
 }

--- a/src/main/java/nebula/plugin/metrics/collector/GradleBuildMetricsCollector.java
+++ b/src/main/java/nebula/plugin/metrics/collector/GradleBuildMetricsCollector.java
@@ -82,6 +82,10 @@ public final class GradleBuildMetricsCollector extends BuildAdapter implements P
     private final Clock clock;
     private BuildMetrics buildMetrics;
 
+    public BuildMetrics getBuildMetrics() {
+        return buildMetrics;
+    }
+
     @Override
     public void settingsEvaluated(Settings settings) {
         checkNotNull(settings);
@@ -310,14 +314,13 @@ public final class GradleBuildMetricsCollector extends BuildAdapter implements P
     }
 
 
-    private void initializeBuildMetrics() {
+    public void initializeBuildMetrics() {
         if(buildMetrics != null) {
             return;
         }
-        long now = clock.getCurrentTime();
         BuildMetrics buildMetrics = new BuildMetrics(gradle.getStartParameter());
         buildMetrics.setBuildStarted(buildStartedTime.getStartTime());
-        buildMetrics.setProfilingStarted(now);
+        buildMetrics.setProfilingStarted(buildStartedTime.getStartTime());
         this.buildMetrics = buildMetrics;
     }
 

--- a/src/main/java/nebula/plugin/metrics/collector/GradleBuildMetricsCollector.java
+++ b/src/main/java/nebula/plugin/metrics/collector/GradleBuildMetricsCollector.java
@@ -19,7 +19,6 @@ package nebula.plugin.metrics.collector;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
-import nebula.plugin.info.InfoBrokerPlugin;
 import nebula.plugin.metrics.MetricsLoggerFactory;
 import nebula.plugin.metrics.dispatcher.MetricsDispatcher;
 import nebula.plugin.metrics.model.GradleToolContainer;
@@ -30,7 +29,6 @@ import nebula.plugin.metrics.model.CompositeOperation;
 import nebula.plugin.metrics.model.ContinuousOperation;
 import nebula.plugin.metrics.model.ProjectMetrics;
 import nebula.plugin.metrics.model.TaskExecution;
-import nebula.plugin.metrics.time.BuildStartedTime;
 import nebula.plugin.metrics.time.Clock;
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
@@ -49,6 +47,8 @@ import org.gradle.api.tasks.TaskState;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
 
+import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -159,7 +159,7 @@ public final class GradleBuildMetricsCollector extends BuildAdapter implements P
             dispatcher.started(project); // We register this listener after the build has started, so we fire the start event here instead
 
             GradleToolContainer tool = GradleToolContainer.fromGradle(gradle);
-            InfoBrokerPlugin plugin = getNebulaInfoBrokerPlugin(gradleProject);
+            Plugin<?> plugin = getNebulaInfoBrokerPlugin(gradleProject);
             if (plugin == null) {
                 dispatcher.environment(Info.create(tool, gradleProject));
             } else {
@@ -171,12 +171,22 @@ public final class GradleBuildMetricsCollector extends BuildAdapter implements P
         }
     }
 
-    private InfoBrokerPlugin getNebulaInfoBrokerPlugin(Project gradleProject) {
-        Plugin plugin = gradleProject.getPlugins().findPlugin("nebula.info-broker");
+    private Map<String, Object> getNebulaInfoBrokerPluginReports(Project gradleProject) {
+        try {
+            Plugin<?> nebulaInfoBrokerPlugin = getNebulaInfoBrokerPlugin(gradleProject);
+            Method method = nebulaInfoBrokerPlugin.getClass().getDeclaredMethod("buildReports");
+            return (Map<String, Object>) method.invoke(nebulaInfoBrokerPlugin);
+        }  catch (Exception e) {
+            return new HashMap<>();
+        }
+    }
+
+    private Plugin<?> getNebulaInfoBrokerPlugin(Project gradleProject) {
+        Plugin<?> plugin = gradleProject.getPlugins().findPlugin("nebula.info-broker");
         if (plugin == null) {
             plugin = gradleProject.getPlugins().findPlugin("info-broker");
         }
-        return plugin != null ? (InfoBrokerPlugin) plugin : null;
+        return plugin;
     }
 
     /*
@@ -191,10 +201,9 @@ public final class GradleBuildMetricsCollector extends BuildAdapter implements P
         MetricsDispatcher dispatcher = dispatcherSupplier.get();
         dispatcher.result(result);
 
-        InfoBrokerPlugin infoBrokerPlugin = getNebulaInfoBrokerPlugin(buildResult.getGradle().getRootProject());
-        if (infoBrokerPlugin != null) {
-            Map<String, Object> reports = infoBrokerPlugin.buildReports();
-            for (Map.Entry<String, Object> report : reports.entrySet()) {
+        Map<String,Object> infoBrokerPluginReports = getNebulaInfoBrokerPluginReports(buildResult.getGradle().getRootProject());
+        if (infoBrokerPluginReports != null) {
+            for (Map.Entry<String, Object> report : infoBrokerPluginReports.entrySet()) {
                 dispatcher.report(report.getKey(), report.getValue());
             }
         }

--- a/src/main/java/nebula/plugin/metrics/time/MonotonicClock.java
+++ b/src/main/java/nebula/plugin/metrics/time/MonotonicClock.java
@@ -20,9 +20,10 @@ import com.google.common.annotations.VisibleForTesting;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
+ * This was taking from Gradle https://github.com/gradle/gradle/blob/v6.4.1/subprojects/base-services/src/main/java/org/gradle/internal/time/MonotonicClock.java
+ *
  * A clock that is guaranteed to not go backwards.
  * <p>
  * It aims to strike a balance between never going backwards (allowing timestamps to represent causality)
@@ -58,15 +59,14 @@ public class MonotonicClock implements Clock {
 
     private final AtomicLong syncMillisRef;
     private final AtomicLong syncNanosRef;
-    private final AtomicLong max = new AtomicLong(0);
+    private final AtomicLong currentTime = new AtomicLong(0);
 
     public MonotonicClock() {
         this(TimeSource.SYSTEM, SYNC_INTERVAL_MILLIS);
     }
 
     @VisibleForTesting
-    public MonotonicClock(TimeSource timeSource, long syncIntervalMillis) {
-        checkNotNull(timeSource);
+    MonotonicClock(TimeSource timeSource, long syncIntervalMillis) {
         long nanoTime = timeSource.nanoTime();
         long currentTimeMillis = timeSource.currentTimeMillis();
 
@@ -74,9 +74,10 @@ public class MonotonicClock implements Clock {
         this.syncIntervalMillis = syncIntervalMillis;
         this.syncNanosRef = new AtomicLong(nanoTime);
         this.syncMillisRef = new AtomicLong(currentTimeMillis);
-        this.max.set(currentTimeMillis);
+        this.currentTime.set(currentTimeMillis);
     }
 
+    @Override
     public long getCurrentTime() {
         long nowNanos = timeSource.nanoTime();
         long syncNanos = syncNanosRef.get();
@@ -95,22 +96,29 @@ public class MonotonicClock implements Clock {
         return sinceSyncMillis >= syncIntervalMillis && syncNanosRef.compareAndSet(syncNanos, nowNanos);
     }
 
+    /**
+     * Syncs our internal clock with the system clock and returns the new time.
+     * Marks the current time as the last synchronization point, unless another thread already did a synchronization in the meantime.
+     */
     private long sync(long syncMillis) {
         long newSyncMillis = advance(timeSource.currentTimeMillis());
-        // CAS due to potentially a later, but overlapping, sync having already completed
         syncMillisRef.compareAndSet(syncMillis, newSyncMillis);
         return newSyncMillis;
     }
 
-    private long advance(long timestamp) {
-        long prev;
-        long next;
-        do {
-            prev = max.get();
-            next = Math.max(prev, timestamp);
-        } while (!max.compareAndSet(prev, next));
-
-        return next;
+    /**
+     * Advance the clock to the given timestamp and return the new time.
+     * The returned time may not be the one passed in, in case another thread already advanced the clock further.
+     * This ensures that all threads share a consistent time.
+     */
+    private long advance(long newTime) {
+        while (true) {
+            long current = currentTime.get();
+            if (newTime <= current) {
+                return current;
+            } else if (currentTime.compareAndSet(current, newTime)) {
+                return newTime;
+            }
+        }
     }
-
 }

--- a/src/main/resources/META-INF/gradle-plugins/nebula.metrics.gradle-plugin.properties
+++ b/src/main/resources/META-INF/gradle-plugins/nebula.metrics.gradle-plugin.properties
@@ -1,0 +1,18 @@
+#
+#  Copyright 2015-2020 Netflix, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+implementation-class=nebula.plugin.metrics.MetricsGradlePlugin

--- a/src/main/resources/META-INF/gradle-plugins/nebula.metrics.gradle-plugin.properties
+++ b/src/main/resources/META-INF/gradle-plugins/nebula.metrics.gradle-plugin.properties
@@ -15,4 +15,4 @@
 #
 #
 
-implementation-class=nebula.plugin.metrics.MetricsGradlePlugin
+implementation-class=nebula.plugin.metrics.MetricsInitPlugin

--- a/src/main/resources/META-INF/gradle-plugins/nebula.metrics.init-plugin.properties
+++ b/src/main/resources/META-INF/gradle-plugins/nebula.metrics.init-plugin.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright 2015-2020 Netflix, Inc.
+#  Copyright 2020 Netflix, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/src/main/resources/META-INF/gradle-plugins/nebula.metrics.settings-plugin.properties
+++ b/src/main/resources/META-INF/gradle-plugins/nebula.metrics.settings-plugin.properties
@@ -1,0 +1,18 @@
+#
+#  Copyright 2015-2020 Netflix, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+implementation-class=nebula.plugin.metrics.MetricsSettingsPlugin

--- a/src/main/resources/META-INF/gradle-plugins/nebula.metrics.settings-plugin.properties
+++ b/src/main/resources/META-INF/gradle-plugins/nebula.metrics.settings-plugin.properties
@@ -1,5 +1,5 @@
 #
-#  Copyright 2015-2020 Netflix, Inc.
+#  Copyright 2020 Netflix, Inc.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.


### PR DESCRIPTION
I took a look at the gradle metrics issue with negative values for elapsed times: https://github.com/nebula-plugins/gradle-metrics-plugin/issues/50

We register a listener here https://github.com/nebula-plugins/gradle-metrics-plugin/blob/master/src/main/java/nebula/plugin/metrics/MetricsPlugin.java#L154-L155

`GradleBuildMetricsCollector` extends `BuildAdapter` -> https://docs.gradle.org/current/javadoc/org/gradle/BuildAdapter.html https://github.com/nebula-plugins/gradle-metrics-plugin/blob/master/src/main/java/nebula/plugin/metrics/collector/GradleBuildMetricsCollector.java

It appears that these methods are never triggered: https://github.com/nebula-plugins/gradle-metrics-plugin/blob/master/src/main/java/nebula/plugin/metrics/collector/GradleBuildMetricsCollector.java#L86-L105

So what happens is that We initialize the build metrics after the project is evaluated for safeness: https://github.com/nebula-plugins/gradle-metrics-plugin/blob/master/src/main/java/nebula/plugin/metrics/collector/GradleBuildMetricsCollector.java#L109

This leads to `0` for those stages so when we try to get the elapsed time in https://github.com/nebula-plugins/gradle-metrics-plugin/blob/master/src/main/java/nebula/plugin/metrics/model/BuildMetrics.java#L208-L217, these are always negative numbers

I created this sample project: https://github.com/nebula-plugins/gradle-nebula-integration/tree/master/gradle-build-adapter-issue

if you run `./gradlew build` you will see a `WE ARE IN AFTER EVALUATE` message in the output but you wouldn't get these exceptions https://github.com/nebula-plugins/gradle-nebula-integration/blob/master/gradle-build-adapter-issue/buildSrc/src/main/groovy/test/nebula/GradleBuildMetricsCollector.groovy#L12-L25

in order to measure settings and project evaluation, the listener has to be applied at Settings or Gradle (Init script) plugin level for example:

```
rootProject.name = 'gradle-build-adapter-issue'
class Test implements Plugin<Settings> {
    @Override
    void apply(Settings settings) {
        final GradleBuildMetricsCollector gradleCollector = new GradleBuildMetricsCollector()
        settings.gradle.addListener(gradleCollector)
    }
}
class GradleBuildMetricsCollector extends BuildAdapter  implements ProjectEvaluationListener {
    @Override
    void settingsEvaluated(Settings settings) {
        throw new RuntimeException("Can run when settings evaluated")
    }
    @Override
    void projectsLoaded(Gradle gradle) {
        throw new RuntimeException("Can not run when projects loaded")
    }
    @Override
    void beforeEvaluate(Project project) {
        throw new RuntimeException("Can not run before evaluate")
    }
    @Override
    void afterEvaluate(Project project, ProjectState projectState) {
        println "WE ARE IN AFTER EVALUATE"
    }
}
apply plugin: Test
```

This PR is to support that and also keep backwards compatibility so folks can migrate at the own pace from project plugin to settings/init plugin via `nebula.metrics.settings-plugin` and `nebula.metrics.init-plugin`

